### PR TITLE
Change the way grouped transforms work

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.7
 DataFrames 0.13
+Tables

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -398,10 +398,10 @@ function transform(g::GroupedDataFrame; kwargs...)
             end
             t = Tables.allocatecolumn(eltype(first), size(result, 1))
             t[idx1[1]:idx2[1]] = first
-            for i in 2:length(g)
+            @inbounds for i in 2:length(g)
                 out = v(g[i])
                 if !(out isa AbstractVector)
-                    throw("Return value must be an `AbstractVector` for all groups or for none of them")
+                    throw(ArgumentError("Return value must be an `AbstractVector` for all groups or for none of them"))
                 elseif length(out) != size(g[i], 1)
                     throw("If a function returns a vector, the result " * 
                           "must have the same length as the groups it operates on")
@@ -417,10 +417,10 @@ function transform(g::GroupedDataFrame; kwargs...)
         else
             t = Tables.allocatecolumn(typeof(first), size(result, 1))
             @views fill!(t[idx1[1]:idx2[1]], first)
-            for i in 2:length(g)
+            @inbounds for i in 2:length(g)
                 out = v(g[i])
                 if out isa AbstractVector
-                    throw("Return value must be an `AbstractVector` for all groups or for none of them")
+                    throw(ArgumentError("Return value must be an `AbstractVector` for all groups or for none of them"))
                 end
                 S = typeof(out)
                 T = eltype(t)

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -393,8 +393,8 @@ function transform(g::GroupedDataFrame; kwargs...)
         first = v(g[1])
         if first isa AbstractVector 
             if length(first) != size(g[1], 1)
-                throw("If a function returns a vector, the result " * 
-                      "must have the same length as the groups it operates on")
+                throw(ArgumentError("If a function returns a vector, the result " * 
+                                    "must have the same length as the groups it operates on"))
             end
             t = Tables.allocatecolumn(eltype(first), size(result, 1))
             t[idx1[1]:idx2[1]] = first
@@ -403,8 +403,8 @@ function transform(g::GroupedDataFrame; kwargs...)
                 if !(out isa AbstractVector)
                     throw(ArgumentError("Return value must be an `AbstractVector` for all groups or for none of them"))
                 elseif length(out) != size(g[i], 1)
-                    throw("If a function returns a vector, the result " * 
-                          "must have the same length as the groups it operates on")
+                    throw(ArgumentError("If a function returns a vector, the result " * 
+                                        "must have the same length as the groups it operates on"))
                 end
                 S = eltype(out)
                 T = eltype(t)

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -1,8 +1,7 @@
 module DataFramesMeta
 
 using DataFrames 
-import Tables: allocatecolumn
-
+using Tables
 # Basics:
 export @with, @where, @orderby, @transform, @by, @based_on, @select
 
@@ -411,7 +410,7 @@ function transform(g::GroupedDataFrame; kwargs...)
                 T = eltype(t)
                 if !(S <: T || promote_type(S, T) <: T)
                     t = copyto!(Tables.allocatecolumn(promote_type(S, T), size(result, 1)), 
-                        t[1:idx2[i-1]])
+                                t[1:idx2[i-1]])
                 end
                 t[idx1[i]:idx2[i]] = out
             end
@@ -424,7 +423,7 @@ function transform(g::GroupedDataFrame; kwargs...)
                 T = eltype(t)
                 if !(S <: T || promote_type(S, T) <: T)
                     t = copyto!(Tables.allocatecolumn(promote_type(S, T), size(result, 1)), 
-                        t[1:idx2[i-1]])
+                                t[1:idx2[i-1]])
                 end
                 t[idx1[i]:idx2[i]] .= out
             end

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -402,6 +402,11 @@ function transform(g::GroupedDataFrame; kwargs...)
             t[idx1[1]:idx2[1]] = first
             for i in 2:length(g)
                 out = v(g[i])
+                if length(out) != size(g[i], 1)
+                    throw("If a function returns a vector, the result " * 
+                      "must have the same length as the groups it " *
+                      "operates on")
+                end
                 S = eltype(out)
                 T = eltype(t)
                 if !(S <: T || promote_type(S, T) <: T)

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -407,7 +407,7 @@ end
 
 function _transform!(t::AbstractVector, first::AbstractVector, start::Int, 
                      g::GroupedDataFrame, v::Function, starts::Vector, ends::Vector)
-    @inline function fill_column_vec!(t::AbstractVector, out, startpoint::Int, endpoint::Int, 
+    @inline function fill_column!(t::AbstractVector, out, startpoint::Int, endpoint::Int, 
                                       len::Int)
         if !(out isa AbstractVector)
             throw(ArgumentError("Return value must be an `AbstractVector` for all groups or" *
@@ -416,10 +416,9 @@ function _transform!(t::AbstractVector, first::AbstractVector, start::Int,
             throw(ArgumentError("If a function returns a vector, the result " * 
                                 "must have the same length as the groups it operates on"))    
         end     
-        elout = eltype(out)
+        eltypout = eltype(out)
         T = eltype(t)
-        newtype = promote_type(elout, T)
-        if elout <: T || newtype <: T
+        if eltypout <: T || (newtype = promote_type(eltypout, T)) <: T
            t[startpoint:endpoint] = out
             return nothing 
         else 
@@ -429,11 +428,11 @@ function _transform!(t::AbstractVector, first::AbstractVector, start::Int,
     end 
 
     # handle the first case 
-    newtype_first = fill_column_vec!(t, first, starts[start], ends[start], size(g[start], 1))
-    #@assert newtype_first === nothing
+    newtype_first = fill_column!(t, first, starts[start], ends[start], size(g[start], 1))
+    @assert newtype_first === nothing
     @inbounds for i in (start+1):length(g)
         out = v(g[i])
-        newtype = fill_column_vec!(t, out, starts[i], ends[i], size(g[i], 1))
+        newtype = fill_column!(t, out, starts[i], ends[i], size(g[i], 1))
         if newtype !== nothing
              t = copyto!(Tables.allocatecolumn(newtype, length(t)), 
                          1, t, 1, ends[i-1])
@@ -445,15 +444,14 @@ end
 
 function _transform!(t::AbstractVector, first::Any, start::Int, 
                      g::GroupedDataFrame, v::Function, starts::Vector, ends::Vector)
-    @inline function fill_column_any!(t::AbstractVector, out, startpoint::Int, endpoint::Int)
+    @inline function fill_column!(t::AbstractVector, out, startpoint::Int, endpoint::Int)
         if out isa AbstractVector
             throw(ArgumentError("Return value must be an `AbstractVector` for all groups or" *
                                  "for none of them"))
         end     
         typout = typeof(out)
         T = eltype(t)
-        newtype = promote_type(typout, T)
-        if typout <: T || newtype <: T
+        if typout <: T || (newtype = promote_type(typout, T)) <: T
             t[startpoint:endpoint] .= Ref(out)
             return nothing
         else 
@@ -461,11 +459,11 @@ function _transform!(t::AbstractVector, first::Any, start::Int,
         end
     end 
     # handle the first case 
-    newtype_first = fill_column_any!(t, first, starts[start], ends[start])
-    #@assert newtype_first === nothing
+    newtype_first = fill_column!(t, first, starts[start], ends[start])
+    @assert newtype_first === nothing
     @inbounds for i in (start+1):length(g)
         out = v(g[i])
-        newtype = fill_column_any!(t, out, starts[i], ends[i])
+        newtype = fill_column!(t, out, starts[i], ends[i])
         if newtype !== nothing
              t = copyto!(Tables.allocatecolumn(newtype, length(t)), 
                          1, t, 1, ends[i-1])
@@ -473,7 +471,6 @@ function _transform!(t::AbstractVector, first::Any, start::Int,
          end
     end
     return t
-
 end
 
 function transform_helper(x, args...)

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -416,7 +416,7 @@ function transform(g::GroupedDataFrame; kwargs...)
             end
         else
             t = Tables.allocatecolumn(typeof(first), size(result, 1))
-            t[idx1[1]:idx2[1]] = fill(first, size(g[1],1))
+            @views fill!(t[idx1[1]:idx2[1]], first)
             for i in 2:length(g)
                 out = v(g[i])
                 if out isa AbstractVector
@@ -428,7 +428,7 @@ function transform(g::GroupedDataFrame; kwargs...)
                     t = copyto!(Tables.allocatecolumn(promote_type(S, T), size(result, 1)), 
                                 1, t, 1, idx2[i-1])
                 end
-                t[idx1[i]:idx2[i]] = fill(out, size(g[i],1))
+                @views fill!(t[idx1[i]:idx2[i]], out)
             end
         end
         result[k] = t

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -1,7 +1,7 @@
 module DataFramesMeta
 
 using DataFrames 
-using Tables
+using Tables: allocatecolumn
 # Basics:
 export @with, @where, @orderby, @transform, @by, @based_on, @select
 
@@ -410,7 +410,7 @@ function transform(g::GroupedDataFrame; kwargs...)
                 T = eltype(t)
                 if !(S <: T || promote_type(S, T) <: T)
                     t = copyto!(Tables.allocatecolumn(promote_type(S, T), size(result, 1)), 
-                                t[1:idx2[i-1]])
+                                1, t, 1, idx2[i-1])
                 end
                 t[idx1[i]:idx2[i]] = out
             end
@@ -423,7 +423,7 @@ function transform(g::GroupedDataFrame; kwargs...)
                 T = eltype(t)
                 if !(S <: T || promote_type(S, T) <: T)
                     t = copyto!(Tables.allocatecolumn(promote_type(S, T), size(result, 1)), 
-                                t[1:idx2[i-1]])
+                                1, t, 1, idx2[i-1])
                 end
                 t[idx1[i]:idx2[i]] .= out
             end

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -405,6 +405,10 @@ function transform(g::GroupedDataFrame; kwargs...)
                     throw("If a function returns a vector, the result " * 
                           "must have the same length as the groups it operates on")
                 end
+                if !(out isa AbstractVector)
+                    throw("return value must not change its kind (single " *
+                          "value, named tuple, vector or data frame) across groups")
+                end
                 S = eltype(out)
                 T = eltype(t)
                 if !(S <: T || promote_type(S, T) <: T)
@@ -418,6 +422,10 @@ function transform(g::GroupedDataFrame; kwargs...)
             t[idx1[1]:idx2[1]] .= first
             for i in 2:length(g)
                 out = v(g[i])
+                if out isa AbstractVector
+                    throw("return value must not change its kind (single " *
+                          "value, named tuple, vector or data frame) across groups")
+                end
                 S = typeof(out)
                 T = eltype(t)
                 if !(S <: T || promote_type(S, T) <: T)

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -394,9 +394,11 @@ function transform(g::GroupedDataFrame; kwargs...)
     for (k, v) in kwargs
         first = v(g[1])
         if first isa AbstractVector
-            t = _transform!(Tables.allocatecolumn(eltype(first), size(result, 1)), first, 1, g, v, starts, ends)
+            t = _transform!(Tables.allocatecolumn(eltype(first), size(result, 1)), 
+                            first, 1, g, v, starts, ends)
         else 
-            t = _transform!(Tables.allocatecolumn(typeof(first), size(result, 1)), first, 1, g, v, starts, ends)
+            t = _transform!(Tables.allocatecolumn(typeof(first), size(result, 1)), 
+                            first, 1, g, v, starts, ends)
         end
         result[k] = t
     end
@@ -405,7 +407,8 @@ end
 
 function _transform!(t::AbstractVector, first::AbstractVector, start::Int, 
                      g::GroupedDataFrame, v::Function, starts::Vector, ends::Vector)
-    @inline function fill_column_vec!(t::AbstractVector, out, startpoint::Int, endpoint::Int, len::Int)
+    @inline function fill_column_vec!(t::AbstractVector, out, startpoint::Int, endpoint::Int, 
+                                      len::Int)
         if !(out isa AbstractVector)
             throw(ArgumentError("Return value must be an `AbstractVector` for all groups or" *
                                 "for none of them"))

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -392,54 +392,79 @@ function transform(g::GroupedDataFrame; kwargs...)
     lengths = [ends[i] - starts[i] + 1 for i in 1:length(starts)]
     for (k, v) in kwargs
         first = v(g[1])
-        if first isa AbstractVector 
-            t = Tables.allocatecolumn(eltype(first), size(result, 1))
-            t[starts[1]:ends[1]] = first
+        if first isa AbstractVector
+            t = _transform!(Tables.allocatecolumn(eltype(first), size(result, 1)), first, 1, g, v, starts, ends)
         else 
-            t = Tables.allocatecolumn(typeof(first), size(result, 1))
-            @views fill!(t[starts[1]:ends[1]], first)
-        end
-        @inbounds for i in 2:length(g)
-            t = _transform!(t, i, v(g[i]), starts, ends, lengths)
+            t = _transform!(Tables.allocatecolumn(typeof(first), size(result, 1)), first, 1, g, v, starts, ends)
         end
         result[k] = t
     end
     return result
 end
 
-function _transform!(t::AbstractVector, i::Int, out::AbstractVector, starts::Vector, ends::Vector, lengths::Vector)
+function _transform!(t::AbstractVector, first::AbstractVector, start::Int, g::GroupedDataFrame, v::Function, starts::Vector, ends::Vector)
+    # handle the first case 
+    j = fill_column_vec!(t, first, starts[start], ends[start], size(g[start], 1))
+    @assert j === nothing
+    for i in (start+1):length(g)
+        out = v(g[i])
+        promoted = fill_column_vec!(t, out, starts[i], ends[i], size(g[i], 1))
+        if !(promoted === nothing)
+             t = copyto!(Tables.allocatecolumn(promoted, length(t)), 
+                         1, t, 1, ends[i-1])
+             _transform!(t, out, i, g, v, starts, ends)
+         end
+    end
+    return t
+end
+
+function _transform!(t::AbstractVector, first::Any, start::Int, g::GroupedDataFrame, v::Function, starts::Vector, ends::Vector)
+    # handle the first case 
+    j = fill_column_any!(t, first, starts[start], ends[start])
+    @assert j === nothing
+    for i in (start+1):length(g)
+        out = v(g[i])
+        promoted = fill_column_any!(t, out, starts[i], ends[i])
+        if !(promoted === nothing)
+             t = copyto!(Tables.allocatecolumn(promoted, length(t)), 
+                         1, t, 1, ends[i-1])
+             _transform!(t, out, i, g, v, starts, ends)
+         end
+    end
+    return t
+end
+
+function fill_column_vec!(t::AbstractVector, out, startpoint::Int, endpoint::Int, len::Int)
     if !(out isa AbstractVector)
          throw(ArgumentError("Return value must be an `AbstractVector` for all groups or for none of them"))
-    elseif length(out) != lengths[i]
+    elseif length(out) != len
         throw(ArgumentError("If a function returns a vector, the result " * 
-                            "must have the same length as the groups it operates on"))
-    end
+                            "must have the same length as the groups it operates on"))    
+    end     
     elout = eltype(out)
     T = eltype(t)
     promoted = promote_type(elout, T)
-    if !(elout <: T || promoted <: T)
-        t = copyto!(Tables.allocatecolumn(promoted, length(t)), 
-                    1, t, 1, ends[i-1])
-        return _transform!(t, i, out, starts, ends, lengths)
+    if (elout <: T || promoted <: T)
+        t[startpoint:endpoint] = out
+    else 
+        return promoted
     end
-    t[starts[i]:ends[i]] = out
-    return t
+    return nothing 
 end 
 
-function _transform!(t::AbstractVector, i::Int, out::Any, starts::Vector, ends::Vector, lengths::Vector)
+function fill_column_any!(t::AbstractVector, out, startpoint::Int, endpoint::Int)
     if (out isa AbstractVector)
-        throw(ArgumentError("Return value must be an `AbstractVector` for all groups or for none of them"))
-    end
+         throw(ArgumentError("Return value must be an `AbstractVector` for all groups or for none of them"))
+    end     
     typout = typeof(out)
     T = eltype(t)
     promoted = promote_type(typout, T)
-    if !(typout <: T || promoted <: T)
-        t = copyto!(Tables.allocatecolumn(promoted, length(t)), 
-                    1, t, 1, ends[i-1])
-        return _transform!(t, i, out, starts, ends, lengths)
+    if (typout <: T || promoted <: T)
+        @views t[startpoint:endpoint] .= Ref(out)
+    else 
+        return promoted
     end
-    @views fill!(t[starts[i]:ends[i]], out)
-    return t
+    return nothing 
 end 
 
 function transform_helper(x, args...)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -30,24 +30,33 @@ d = DataFrame(a = [1,1,1,2,2,3,3,1],
 g = groupby(d, :a, sort = false)
 ## Scalar output 
 # Type promotion Int -> Float
-@test isequal(@transform(g, t = :b[1])[:t], 
-              [1.0, 1.0, 1.0, 1.0, missing, missing, 6.0, 6.0])
+t = @transform(g, t = :b[1])[:t] 
+correct = [1.0, 1.0, 1.0, 1.0, missing, missing, 6.0, 6.0]
+@test all(t .=== correct) && typeof(t) == typeof(correct)
 # Type promotion Number -> Any
-@test (@transform(g, t = isequal(:b[1], 1) ? :b[1] : "a")[:t] .=== 
-                  [1, 1, 1, 1,"a" ,"a" ,"a" ,"a"]) |> all
+t = @transform(g, t = isequal(:b[1], 1) ? :b[1] : "a")[:t]
+correct = Any[1, 1, 1, 1,"a" ,"a" ,"a" ,"a"]
+@test all(t .=== correct) && typeof(t) == typeof(correct)
 ## Vector output 
 # Normal use
-@test isequal(@transform(g, t = :b .- mean(:b))[:t],
-              [-1.5, -0.5, 0.5, 1.5, missing, missing, 0.5, -0.5])
+t = @transform(g, t = :b .- mean(:b))[:t]
+correct = Union{Float64, Missing}[-1.5, -0.5, 0.5, 1.5, missing, missing, 0.5, -0.5]
+@test all(t .=== correct) && typeof(t) == typeof(correct)
 # Type promotion
-@test (@transform(g, t = isequal(:b[1], 1) ? fill(1, length(:b)) : fill(2.0, length(:b)))[:t] .=== 
-                  [1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0]) |> all
+t = @transform(g, t = isequal(:b[1], 1) ? fill(1, length(:b)) : fill(2.0, length(:b)))[:t] 
+correct = Float64[1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0]
+@test all(t .=== correct) && typeof(t) == typeof(correct)
 # Vectors of different types
-@test (@transform(g, t = isequal(:b[1], 1) ? :b : fill("a", length(:b)))[:t] .=== 
-                  [1, 2, 3, 4, "a", "a", "a", "a"]) |> all
+t = @transform(g, t = isequal(:b[1], 1) ? :b : fill("a", length(:b)))[:t]
+correct = Any[1, 2, 3, 4, "a", "a", "a", "a"]
+@test all(t .=== correct) && typeof(t) == typeof(correct)
 # Categorical Categorical Array 
 # Scalar
-@test @transform(g, t = :c[1])[:t] == CategoricalArray([1, 1, 1, 1, 1, 1, 3, 3])
+t = @transform(g, t = :c[1])[:t]
+correct = CategoricalArray([1, 1, 1, 1, 1, 1, 3, 3])
+@test all(isequal.(t, correct)) && typeof(t) == typeof(correct)
 # Vector 
-@test @transform(g, t = :c)[:t] == CategoricalArray([1, 2, 3, 2, 1, 2, 3, 1])
+t = @transform(g, t = :c)[:t]
+correct = CategoricalArray([1, 2, 3, 2, 1, 2, 3, 1])
+@test all(isequal.(t, correct)) && typeof(t) == typeof(correct)
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -53,10 +53,10 @@ t = @transform(g, t = isequal(:b[1], 1) ? :b : fill("a", length(:b)))[:t]
 # Categorical Array 
 # Scalar
 t = @transform(g, t = :c[1])[:t]
-correct = CategoricalArray([1, 1, 1, 1, 1, 1, 3, 3])
-@test isequal(t, correct) && typeof(t) == typeof(correct)
+@test isequal(t, CategoricalArray([1, 1, 1, 1, 1, 1, 3, 3])) && 
+      t isa CategoricalVector{Int}
 # Vector 
 t = @transform(g, t = :c)[:t]
-correct = CategoricalArray([1, 2, 3, 2, 1, 2, 3, 1])
-@test isequal(t, correct) && typeof(t) == typeof(correct)
+@test isequal(t, CategoricalArray([1, 2, 3, 2, 1, 2, 3, 1])) && 
+      t isa CategoricalVector{Int}
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -46,7 +46,7 @@ t = @transform(g, t = :b .- mean(:b))[:t]
 t = @transform(g, t = isequal(:b[1], 1) ? fill(1, length(:b)) : fill(2.0, length(:b)))[:t] 
 @test isequal(t, [1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0]) && 
       t isa Vector{Float64}
-# Vectors of different types
+# Vectors whose eltypes promote to any
 t = @transform(g, t = isequal(:b[1], 1) ? :b : fill("a", length(:b)))[:t]
 @test isequal(t, [1, 2, 3, 4, "a", "a", "a", "a"]) && 
       t isa Vector{Any}

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -23,8 +23,23 @@ d = DataFrame(n = 1:20, x = [3, 3, 3, 3, 1, 1, 1, 2, 1, 1, 2, 1, 1, 2, 2, 2, 3, 
 g = groupby(d, :x, sort=true)
 @test @based_on(g, nsum = sum(:n))[:nsum] == [99, 84, 27]
 
-d = DataFrame(a = [1,1,1,2,2], b = [1,2,3,missing,missing])
+# Transform tests
+d = DataFrame(a = [1,1,1,2,2,3,3,1], 
+              b = Any[1,2,3,missing,missing,6.0,5.0,4], 
+              c = CategoricalArray([1,2,3,1,2,3,1,2]))
 g = groupby(d, :a)
-@test isequal(@transform(g, t = mean(:b))[:t], [2.0, 2.0, 2.0, missing, missing])
-@test isequal(@transform(g, t = fill(:b[1], length(:b))), [1, 1, 1, missing, missing])
+## Scalar output 
+# Type promotion Int -> Float
+@test @transform(g, t = :b[1])[1, :t] == 1.0
+# Type promotion Number -> Any
+@test @transform(g, t = isequal(:b[1], 1) ? :b[1] : "a")[1, :t] == 1
+## Vector output 
+# Normal use
+@test @transform(g, t = :b .- mean(:b))[:t][1, :t] == -1.5
+# Type promotion
+@test @transform(g, t = isequal(:b[1], 1) ? fill(1, length(:b)) : fill(2.0, length(:b)))[1, :t] == 1.0
+# Vectors of different types
+@test @transform(g, t = isequal(:b[1], 1) ? :b : fill("a", length(:b)))[1, :t] == 1
+# Categorical Categorical Array 
+
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -53,10 +53,10 @@ t = @transform(g, t = isequal(:b[1], 1) ? :b : fill("a", length(:b)))[:t]
 # Categorical Array 
 # Scalar
 t = @transform(g, t = :c[1])[:t]
-@test isequal(t, CategoricalArray([1, 1, 1, 1, 1, 1, 3, 3])) && 
+@test isequal(t, [1, 1, 1, 1, 1, 1, 3, 3]) && 
       t isa CategoricalVector{Int}
 # Vector 
 t = @transform(g, t = :c)[:t]
-@test isequal(t, CategoricalArray([1, 2, 3, 2, 1, 2, 3, 1])) && 
+@test isequal(t, [1, 2, 3, 2, 1, 2, 3, 1]) && 
       t isa CategoricalVector{Int}
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -27,36 +27,36 @@ g = groupby(d, :x, sort=true)
 d = DataFrame(a = [1,1,1,2,2,3,3,1], 
               b = Any[1,2,3,missing,missing,6.0,5.0,4], 
               c = CategoricalArray([1,2,3,1,2,3,1,2]))
-g = groupby(d, :a, sort = false)
+g = groupby(d, :a)
 ## Scalar output 
 # Type promotion Int -> Float
 t = @transform(g, t = :b[1])[:t] 
-correct = [1.0, 1.0, 1.0, 1.0, missing, missing, 6.0, 6.0]
-@test all(t .=== correct) && typeof(t) == typeof(correct)
+@test isequal(t, [1.0, 1.0, 1.0, 1.0, missing, missing, 6.0, 6.0]) && 
+      t isa Vector{Union{Float64, Missing}}
 # Type promotion Number -> Any
 t = @transform(g, t = isequal(:b[1], 1) ? :b[1] : "a")[:t]
-correct = Any[1, 1, 1, 1,"a" ,"a" ,"a" ,"a"]
-@test all(t .=== correct) && typeof(t) == typeof(correct)
+@test isequal(t, [1, 1, 1, 1, "a", "a", "a", "a"]) && 
+      t isa Vector{Any}
 ## Vector output 
 # Normal use
 t = @transform(g, t = :b .- mean(:b))[:t]
-correct = Union{Float64, Missing}[-1.5, -0.5, 0.5, 1.5, missing, missing, 0.5, -0.5]
-@test all(t .=== correct) && typeof(t) == typeof(correct)
+@test isequal(t, [-1.5, -0.5, 0.5, 1.5, missing, missing, 0.5, -0.5]) && 
+      t isa Vector{Union{Float64, Missing}}
 # Type promotion
 t = @transform(g, t = isequal(:b[1], 1) ? fill(1, length(:b)) : fill(2.0, length(:b)))[:t] 
-correct = Float64[1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0]
-@test all(t .=== correct) && typeof(t) == typeof(correct)
+@test isequal(t, [1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0]) && 
+      t isa Vector{Float64}
 # Vectors of different types
 t = @transform(g, t = isequal(:b[1], 1) ? :b : fill("a", length(:b)))[:t]
-correct = Any[1, 2, 3, 4, "a", "a", "a", "a"]
-@test all(t .=== correct) && typeof(t) == typeof(correct)
-# Categorical Categorical Array 
+@test isequal(t, [1, 2, 3, 4, "a", "a", "a", "a"]) && 
+      t isa Vector{Any}
+# Categorical Array 
 # Scalar
 t = @transform(g, t = :c[1])[:t]
 correct = CategoricalArray([1, 1, 1, 1, 1, 1, 3, 3])
-@test all(isequal.(t, correct)) && typeof(t) == typeof(correct)
+@test isequal(t, correct) && typeof(t) == typeof(correct)
 # Vector 
 t = @transform(g, t = :c)[:t]
 correct = CategoricalArray([1, 2, 3, 2, 1, 2, 3, 1])
-@test all(isequal.(t, correct)) && typeof(t) == typeof(correct)
+@test isequal(t, correct) && typeof(t) == typeof(correct)
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -26,5 +26,6 @@ g = groupby(d, :x, sort=true)
 d = DataFrame(a = [1,1,1,2,2], b = [1,2,3,missing,missing])
 g = groupby(d, :a)
 @test isequal(@transform(g, t = mean(:b))[:t], [2.0, 2.0, 2.0, missing, missing])
+@test isequal(@transform(g, t = fill(:b[1], length(:b))), [1, 1, 1, missing, missing])
 
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -27,5 +27,4 @@ d = DataFrame(a = [1,1,1,2,2], b = [1,2,3,missing,missing])
 g = groupby(d, :a)
 @test isequal(@transform(g, t = mean(:b))[:t], [2.0, 2.0, 2.0, missing, missing])
 @test isequal(@transform(g, t = fill(:b[1], length(:b))), [1, 1, 1, missing, missing])
-
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -22,4 +22,8 @@ d = DataFrame(n = 1:20, x = [3, 3, 3, 3, 1, 1, 1, 2, 1, 1, 2, 1, 1, 2, 2, 2, 3, 
 g = groupby(d, :x, sort=true)
 @test @based_on(g, nsum = sum(:n))[:nsum] == [99, 84, 27]
 
+d = DataFrame(a = [1,1,1,2,2], b = [1,2,3,missing,missing])
+g = groupby(d, :a)
+@test isequal(@transform(g, t = mean(:b))[:t], [2.0, 2.0, 2.0, missing, missing])
+
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -6,6 +6,7 @@ using Test
 using DataFrames
 using DataFramesMeta
 using Statistics
+using Tables
 
 d = DataFrame(n = 1:20, x = [3, 3, 3, 3, 1, 1, 1, 2, 1, 1, 2, 1, 1, 2, 2, 2, 3, 1, 1, 2])
 g = groupby(d, :x, sort=true)


### PR DESCRIPTION
With this PR, now we allocate a vector using `reduce(v ...generator for all operations on groups...)` 

however I still have an error with type promotions. Consider the following example:

```
 df = DataFrame(a = [1,2,3, missing, missing], b = [1,1,1,2,2])
g = groupby(df, :b)
 @transform(g, x = mean(:a))
```

It seems like `reduce(append!, t(ig) for ig in g` should automatically promote types, but it doesn't. 
