### PR TITLE
Fix duplicate condition in check

### DIFF
--- a/test/speedtests.jl
+++ b/test/speedtests.jl
@@ -39,7 +39,7 @@ end
 function dot8(a::Vector, b::Vector)
     x = 0.0
     for i in 1:length(a)
-        if !(isnan(a[i]) || isnan(a[i]))
+        if !(isnan(a[i]) || isnan(b[i]))
             x += a[i] * b[i]
         end
     end


### PR DESCRIPTION
The left and right hand side are the same, I'm guessing this is supposed to be `isnan(b[i])`? Alternatively, it looks like the duplicate expression can be removed.