### PR TITLE
Update @by/@based_on macros to avoid constructing DataFrames

### DIFF
--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -606,7 +606,15 @@ end
 
 function by_helper(x, what, args...)
     :($by($x, $what,
-          $(with_anonymous(:($DataFrame($(map(replace_equals_with_kw, args)...)))))))
+          $(with_anonymous(Expr(:tuple, map(replace_kw_with_equals, args)...)))))
+end
+
+function replace_kw_with_equals(e)
+    if e.head == :kw
+        Expr(:(=), e.args[1], e.args[2])
+    else
+        e
+    end
 end
 
 """

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -536,7 +536,7 @@ end
 
 function based_on_helper(x, args...)
     with_args =
-        with_anonymous(:($DataFrame($(map(replace_equals_with_kw, args)...))))
+        with_anonymous(Expr(:tuple, map(replace_kw_with_equals, args)...))
     :( DataFrames.DataFrame(map($with_args, $x)))
 end
 


### PR DESCRIPTION
Currently, both the `@by` and the `@based_on` macros construct DataFrames on each anonymous function call.  When aggregating over a large number of groups, this can become very costly.  This PR changes the helper functions to  return NamedTuples instead.  

Before this PR:
```julia
julia> using DataFrames, Random, DataFramesMeta
julia> Random.seed!(1234);
julia> df = DataFrame(id = repeat(1:1_000_000, 10), X = randn(10_000_000), Y = randn(10_000_000));
julia> @btime @by($df, :id, X = mean(:X), Y = mean(:Y));
  8.706 s (73999190 allocations: 4.39 GiB)
```
After:
```julia
julia> using DataFrames, Random, DataFramesMeta
julia> Random.seed!(1234);
julia> df = DataFrame(id = repeat(1:1_000_000, 10), X = randn(10_000_000), Y = randn(10_000_000));
julia> @btime @by($df, :id, X = mean(:X), Y = mean(:Y));
  952.237 ms (16999142 allocations: 936.71 MiB)
```
