### PR TITLE
transform(::AbstractDataFrame) broadcasting

### DIFF
--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -375,14 +375,13 @@ end
 
 function transform(d::AbstractDataFrame; kwargs...)
     result = copy(d)
-    nr = size(d, 1)
     for (k, v) in kwargs
         if isa(v, Array)
             result[!, k] = v
         elseif isa(v, Function)
             result[!, k] = v(d)
         else
-            result[!, k] = fill(v, nr)
+            result[!, k] .= v
         end
     end
     return result

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -375,8 +375,15 @@ end
 
 function transform(d::AbstractDataFrame; kwargs...)
     result = copy(d)
+    nr = size(d, 1)
     for (k, v) in kwargs
-        result[!, k] = isa(v, Function) ? v(d) : v
+        if isa(v, Array)
+            result[!, k] = v
+        elseif isa(v, Function)
+            result[!, k] = v(d)
+        else
+            result[!, k] = fill(v, nr)
+        end
     end
     return result
 end


### PR DESCRIPTION
Change transform(::AbstractDataFrame) so it automatically broadcasts non-Array results.

transform(::GroupedDataFrame) already worked this way.

Although the behavior was inconsistent between the two in the current state, this will probably break things for people. Also, this is untested behavior (because the tests passed both before and after).