### PR TITLE
Broadcasting in transform(::AbstractDataFrame,...)

### DIFF
--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -380,7 +380,7 @@ function transform(d::AbstractDataFrame; kwargs...)
         if isa(res, AbstractArray)
             result[!, k] = res
         else
-            result[!, k] .= res
+            result[!, k] .= Ref(res)
         end
     end
     return result
@@ -486,7 +486,7 @@ end
 
 Add additional columns or keys based on keyword arguments.
 Broadcasting occurs if the assigned value is not an 
-AbstractArray.
+`AbstractArray`.
 
 ### Arguments
 

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -376,7 +376,12 @@ end
 function transform(d::AbstractDataFrame; kwargs...)
     result = copy(d)
     for (k, v) in kwargs
-        result[!, k] .= isa(v, Function) ? v(d) : v
+        res = isa(v, Function) ? v(d) : v
+        if isa(res, Array)
+            result[!, k] = res
+        else
+            result[!, k] .= res
+        end
     end
     return result
 end

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -377,7 +377,7 @@ function transform(d::AbstractDataFrame; kwargs...)
     result = copy(d)
     for (k, v) in kwargs
         res = isa(v, Function) ? v(d) : v
-        if isa(res, Array)
+        if isa(res, AbstractArray)
             result[!, k] = res
         else
             result[!, k] .= res

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -379,6 +379,8 @@ function transform(d::AbstractDataFrame; kwargs...)
         res = isa(v, Function) ? v(d) : v
         if isa(res, AbstractArray)
             result[!, k] = res
+        elseif isa(res, Ref)
+            result[!, k] .= res
         else
             result[!, k] .= Ref(res)
         end

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -485,6 +485,8 @@ end
     @transform(d, i...)
 
 Add additional columns or keys based on keyword arguments.
+Broadcasting occurs if the assigned value is not an 
+AbstractArray.
 
 ### Arguments
 

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -376,7 +376,7 @@ end
 function transform(d::AbstractDataFrame; kwargs...)
     result = copy(d)
     for (k, v) in kwargs
-        result[!, k] = isa(v, Function) ? v(d) : v
+        result[!, k] .= isa(v, Function) ? v(d) : v
     end
     return result
 end

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -33,10 +33,14 @@ x = [2, 1, 0]
 
 @test DataFramesMeta.transform(df, C = x).C == x # non-macro function test
 @test @transform(df, C = x).C === x # vector assignment, confirming no reallocation
-@test all(@transform(df, C = :A + :B).C .=== df.A + df.B) # basic correctness test
-@test all(@transform(df, C = 1).C .=== 1) # scalar broadcasting
-@test all(@transform(df, C = 1:3).C .=== [1,2,3]) # range assignment
-@test all(@transform(df, C = Ref(x)).C .=== Ref(x)) # Ref broadcasting
+@test @transform(df, C = :A + :B).C == df.A + df.B # basic correctness test
+@test @transform(df, C = 1).C == [1,1,1] # scalar broadcasting
+@test @transform(df, C = 1:3).C == collect(1:3) # range assignment
+
+# @test @transform(df, C = Ref(x)).C .== [Ref(x), Ref(x), Ref(x)] # Ref broadcasting
+
+x = (1,2,3)
+@test @transform(df, C = x).C == [x,x,x] # tuple broadcasting
 
 @test DataFramesMeta.where(df, 1) == df[1, :]
 

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -29,6 +29,15 @@ idx2 = :B
 @test  @with(df, df[:A .> 1, ^([:B, :A])]) == df[df.A .> 1, [:B, :A]]
 @test  @with(df, DataFrame(a = :A * 2, b = :A .+ :B)) == DataFrame(a = df.A * 2, b = df.A .+ df.B)
 
+x = [2, 1, 0]
+
+@test DataFramesMeta.transform(df, C = x).C == x # non-macro function test
+@test @transform(df, C = x).C === x # vector assignment, confirming no reallocation
+@test all(@transform(df, C = :A + :B).C .=== df.A + df.B) # basic correctness test
+@test all(@transform(df, C = 1).C .=== 1) # scalar broadcasting
+@test all(@transform(df, C = 1:3).C .=== [1,2,3]) # range assignment
+@test all(@transform(df, C = Ref(x)).C .=== Ref(x)) # Ref broadcasting
+
 @test DataFramesMeta.where(df, 1) == df[1, :]
 
 @test  @where(df, :A .> 1)          == df[df.A .> 1,:]

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -37,7 +37,7 @@ x = [2, 1, 0]
 @test @transform(df, C = 1).C == [1,1,1] # scalar broadcasting
 @test @transform(df, C = 1:3).C == collect(1:3) # range assignment
 
-# @test @transform(df, C = Ref(x)).C .== [Ref(x), Ref(x), Ref(x)] # Ref broadcasting
+@test all(@transform(df, C = Ref(x)).C .== Ref(x)) # Ref broadcasting
 
 x = (1,2,3)
 @test @transform(df, C = x).C == [x,x,x] # tuple broadcasting


### PR DESCRIPTION
Change transform(::AbstractDataFrame,...) to use
the broadcasting assignment operator (.=) instead of
the normal one. Array .= Array works, but so does
Array .= Non-Array. If someone provides an Array that
has the wrong dimensions,
`DimensionMismatch("array could not be broadcast to match destination")`
will appear and is pretty self-explanatory.

The `transform(::GroupedDataFrame)` already effectively
broadcasted values.