### PR TITLE
Deprecates `@byrow!` in favor of `@byrow`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,16 @@ Add additional columns based on keyword arguments.
 @transform(df, newCol = cos.(:x), anotherCol = :x.^2 + 3*:x .+ 4)
 ```
 
-## `@byrow!`
+## `@byrow`
 
-Act on a DataFrame row-by-row. Includes support for control flow and `begin end` blocks. Since the "environment" induced by `@byrow! df` is implicitly a single row of `df`, one uses regular operators and comparisons instead of their elementwise counterparts as in `@with`.
+Act on a DataFrame row-by-row. Includes support for control flow and `begin end` blocks. Since the "environment" induced by `@byrow df` is implicitly a single row of `df`, one uses regular operators and comparisons instead of their elementwise counterparts as in `@with`. Does not change the input data frame argument.
 
 ```julia
-@byrow! df if :A > :B; :A = :B * :C end
+changed_df = @byrow df if :A > :B; :A = :B * :C end
 ```
 ```julia
 let x = 0.0
-    @byrow! df begin
+    @byrow df begin
         if :A < :B
             x += :B * :C
         end
@@ -98,18 +98,16 @@ end
 ```
 
 Note that the let block is required here to create a scope to allow assignment
-of `x` within `@byrow!`.
+of `x` within `@byrow`.
 
-`byrow!` also supports special syntax for allocating new columns to make
-`byrow!` more useful for data transformations. The syntax `@newcol
+`byrow` also supports special syntax for allocating new columns to make
+`byrow` more useful for data transformations. The syntax `@newcol
 x::Array{Int}` allocates a new column `:x` with an `Array` container with eltype
-`Int`. Note that the returned `AbstractDataFrame` includes these new columns, but
-the original `df` is not affected. Here is an example where two new columns are
-added:
+`Int`. Here is an example where two new columns are added:
 
 ```julia
 df = DataFrame(A = 1:3, B = [2, 1, 2])
-df2 = @byrow! df begin
+df2 = @byrow df begin
     @newcol colX::Array{Float64}
     @newcol colY::Array{Union{Int,Missing}}
     :colX = :B == 2 ? pi * :A : :B

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Add additional columns based on keyword arguments.
 Act on a DataFrame row-by-row. Includes support for control flow and `begin end` blocks. Since the "environment" induced by `@byrow df` is implicitly a single row of `df`, one uses regular operators and comparisons instead of their elementwise counterparts as in `@with`. Does not change the input data frame argument.
 
 ```julia
-changed_df = @byrow df if :A > :B; :A = :B * :C end
+df2 = @byrow df if :A > :B; :A = :B * :C end
 ```
 ```julia
 let x = 0.0

--- a/src/byrow.jl
+++ b/src/byrow.jl
@@ -4,7 +4,7 @@ export @byrow
 
 ##############################################################################
 ##
-## @byrow and @byrow!
+## @byrow
 ##
 ##############################################################################
 
@@ -85,7 +85,7 @@ transformations. `_N` is introduced to represent the length of the dataframe,
 `_D` represents the `dataframe` including added columns, and `row` represents
 the index of the current row.
 
-Changes to the rows do not affect `d` but instead the new data frame returned
+Changes to the rows do not affect `d` but instead a freshly allocated data frame is returned
 by `@byrow`. Also note that the returned data frame does not share columns
 with `d`.
 

--- a/src/byrow.jl
+++ b/src/byrow.jl
@@ -4,7 +4,7 @@ export @byrow
 
 ##############################################################################
 ##
-## @byrow!
+## @byrow and @byrow!
 ##
 ##############################################################################
 
@@ -60,23 +60,34 @@ end
 """
     @byrow!(d, expr)
 
+Deprecated version of `@byrow`, see: [`@byrow`](@ref)
+
+Acts the exact same way. It does not change the input argument `d` in-place.
+"""
+macro byrow!(df, body)
+    esc(byrow_helper(df, body, true))
+end
+
+"""
+    @byrow(d, expr)
+
 Act on a DataFrame row-by-row.
 
-Changes to the rows do not affect `d` but instead the new data frame returned by
-`@byrow!`. Deprecated in favor of `@byrow` which works the exact same way.
-
 Includes support for control flow and `begin end` blocks. Since the
-"environment" induced by `@byrow! df` is implicitly a single row of `df`,
+"environment" induced by `@byrow df` is implicitly a single row of `df`,
 use regular operators and comparisons instead of their elementwise counterparts
-as in `@with`. Note that the scope within `@byrow!` is a hard scope.
+as in `@with`. Note that the scope within `@byrow` is a hard scope.
 
-`byrow!` also supports special syntax for allocating new columns. The syntax
+`byrow` also supports special syntax for allocating new columns. The syntax
 `@newcol x::Array{Int}` allocates a new column `:x` with an `Array` container
-with eltype `Int`.This feature makes it easier to use `byrow!` for data transformations.
-`_N` is introduced to represent the length of the dataframe, `_D` represents the `dataframe`
-including added columns, and `row` represents the index of the current row.
+with eltype `Int`.This feature makes it easier to use `byrow` for data
+transformations. `_N` is introduced to represent the length of the dataframe,
+`_D` represents the `dataframe` including added columns, and `row` represents
+the index of the current row.
 
-Also note that the returned data frame does not share columns with `d`.
+Changes to the rows do not affect `d` but instead the new data frame returned
+by `@byrow`. Also note that the returned data frame does not share columns
+with `d`.
 
 ### Arguments
 
@@ -95,7 +106,7 @@ julia> using DataFrames, DataFramesMeta
 julia> df = DataFrame(A = 1:3, B = [2, 1, 2]);
 
 julia> let x = 0
-            @byrow! df begin
+            @byrow df begin
                 if :A + :B == 3
                     x += 1
                 end
@@ -104,7 +115,7 @@ julia> let x = 0
         end
 2
 
-julia> @byrow! df begin
+julia> @byrow df begin
             if :A > :B
                 :A = 0
             end
@@ -116,7 +127,7 @@ julia> @byrow! df begin
 │ 2   │ 0 │ 1 │
 │ 3   │ 0 │ 2 │
 
-julia> df2 = @byrow! df begin
+julia> df2 = @byrow df begin
            @newcol colX::Array{Float64}
            :colX = :B == 2 ? pi * :A : :B
        end
@@ -128,13 +139,6 @@ julia> df2 = @byrow! df begin
 │ 3   │ 0 │ 2 │ 0.0     │
 ```
 
-"""
-macro byrow!(df, body)
-    esc(byrow_helper(df, body, true))
-end
-
-"""
-See: [`@byrow!`](@ref)
 """
 macro byrow(df, body)
     esc(byrow_helper(df, body, false))

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -43,16 +43,24 @@ idx2 = :B
 
 @test DataFramesMeta.orderby(df, df[[1, 3, 2], :]) == df[[1, 3, 2], :]
 
-@test @byrow!(df, if :A > :B; :A = 0 end) == DataFrame(A = [1, 0, 0], B = [2, 1, 2])
+@test @byrow(df, if :A > :B; :A = 0 end) == DataFrame(A = [1, 0, 0], B = [2, 1, 2])
+
+# No test for checking if the `@byrow!` deprecation warning exists because it
+# seems like Test.@test_logs (or Test.collect_test_logs) does not play nice
+# with macros.  The existence of the deprecation can be confirmed, however,
+# from the fact it appears a single time (because of the test below) when
+# `] test` is run.
+@test @byrow(df, if :A > :B; :A = 0 end) == @byrow!(df, if :A > :B; :A = 0 end)
+
 @test  df == DataFrame(A = [1, 2, 3], B = [2, 1, 2])
 
 df = DataFrame(A = 1:3, B = [2, 1, 2])  # Restore df
 y = 0
-@byrow!(df, if :A + :B == 3; global y += 1 end)
+@byrow(df, if :A + :B == 3; global y += 1 end)
 @test  y == 2
 
 df = DataFrame(A = 1:3, B = [2, 1, 2])
-df2 = @byrow! df begin
+df2 = @byrow df begin
     @newcol colX::Array{Float64}
     @newcol colY::Array{Float64}
     :colX = :B == 2 ? pi * :A : :B


### PR DESCRIPTION
The `@byrow!` is simply duplicated and renamed to `@byrow` (also exported). The only difference is that one of them triggers the deprecation warning and the other does not. `@byrow!` documentation mention the deprecation and `@byrow` documentation just points to `@byrow!` documentation.