### PR TITLE
Make DataFrames piping functions the backend for @transform, @select, @by, and @based_on

### DIFF
--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -52,14 +52,14 @@ DataFrames's `source => fun => destination` syntax.
 
 ### Details
 
-Parsing follows the same convention as other DataFramesMeta macros, such as `@with`. All
-terms in the expression that are `Symbols` are treated as columns in the data frame, except
+Parsing follows the same convention as other DataFramesMeta.jl macros, such as `@with`. All
+terms in the expression that are `Symbol`s are treated as columns in the data frame, except
 `Symbol`s wrapped in `^`. To use a variable representing a column name, wrap the variable
 in `cols`.
 
-`@col` constructs an anonymous function based off the given expression. It then creates
+`@col` constructs an anonymous function `fun` based on the given expression. It then creates
 a `source => fun => destination` pair that is suitable for the `select`, `transform`, and
-`combine` functions in DataFrames.
+`combine` functions in DataFrames.jl.
 
 ### Examples
 

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -461,10 +461,15 @@ end
 
 
 function transform_helper(x, args...)
+
     t = [fun_to_vec(arg) for arg in args]
 
     quote
-        $DataFrames.transform($x, $(t...))
+        out = $DataFrames.transform($x, $(t...))
+        if $x isa GroupedDataFrame
+            sort!(out, $groupcols($x))
+        end
+        out
     end
 end
 

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -514,8 +514,8 @@ function based_on_helper(x, args...)
     if length(args) == 1 &&
         !(first(args) isa QuoteNode) &&
         !(first(args).head == :(=) || first(args).head == :kw)
+
         t = fun_to_vec(first(args); combinefun = true)
-        @show t
         quote
             $DataFrames.combine($t, $x)
         end
@@ -595,6 +595,7 @@ function by_helper(x, what, args...)
     if length(args) == 1 &&
         !(first(args) isa QuoteNode) &&
         !(first(args).head == :(=) || first(args).head == :kw)
+
         t = fun_to_vec(first(args); combinefun = true)
         quote
             $DataFrames.combine($t, $groupby($x, $what))

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -172,42 +172,25 @@ function fun_to_vec(kw::Expr; byrow = false)
         body = replace_syms!(kw.args[2], membernames)
 
         if byrow == false
-            # z = :x + :y
-            if kw.args[1] isa Symbol
-                t = quote
-                    $(Expr(:vect, keys(membernames)...)) => function $funname($(values(membernames)...))
-                        $body
-                    end => $(QuoteNode(output))
-                end
-            # n = :z
-            # cols(n) = :x + :y
-            elseif DataFramesMeta.onearg(kw.args[1], :cols)
-                t = quote
-                    $(Expr(:vect, keys(membernames)...)) => function $funname($(values(membernames)...))
-                        $body
-                    end => $(output.args[2])
-                end
-            end
+           t = quote
+               $(Expr(:vect, keys(membernames)...)) => function $funname($(values(membernames)...))
+                   $body
+               end => $(QuoteNode(output))
+           end
         else
-            if kw.args[1] isa Symbol
-                t = quote
-                    $(Expr(:vect, keys(membernames)...)) => $(ByRow)(function $funname($(values(membernames)...))
-                        $body
-                    end) => $(QuoteNode(output))
-                end
-            elseif DataFramesMeta.onearg(kw.args[1], :cols)
-                t = quote
-                    $(Expr(:vect, keys(membernames)...)) => $(ByRow)(function $funname($(values(membernames)...))
-                        $body
-                    end) => $(output.args[2])
-                end
+            t = quote
+                $(Expr(:vect, keys(membernames)...)) => $(ByRow)(function $funname($(values(membernames)...))
+                    $body
+                end) => $(QuoteNode(output))
             end
         end
         return t
     else
-        return kw
+        throw(ArgumentError("Expressions not of the form `y = f(:x)` currently disallowed."))
     end
 end
+
+fun_to_vec(kw::QuoteNode) = kw
 
 
 protect_replace_syms!(e, membernames) = e

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -3,7 +3,7 @@ module DataFramesMeta
 using DataFrames, Tables
 
 # Basics:
-export @with, @where, @orderby, @transform, @by, @based_on, @select, @col, @row
+export @with, @where, @orderby, @transform, @by, @based_on, @select, @col
 
 include("linqmacro.jl")
 include("byrow.jl")

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -460,7 +460,7 @@ function transform_helper(x, args...)
     quote
         out = $DataFrames.transform($x, $(t...))
         if $x isa GroupedDataFrame
-            sort!(out, $groupcols($x))
+            out = out[$x.idx, :]
         end
         out
     end

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -464,7 +464,9 @@ function transform_helper(x, args...)
     quote
         out = $DataFrames.transform($x, $(t...))
         if $x isa GroupedDataFrame
-            out = out[$x.idx, :]
+            for col in eachcol(out)
+                permute!(col, x.idx)
+            end
         end
         out
     end

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -464,9 +464,7 @@ function transform_helper(x, args...)
     quote
         out = $DataFrames.transform($x, $(t...))
         if $x isa GroupedDataFrame
-            for col in eachcol(out)
-                permute!(col, x.idx)
-            end
+            out = out[$x.idx, :]
         end
         out
     end

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -98,7 +98,6 @@ end
 function fun_to_vec(kw::Expr; combinefun = false)
     if kw.head == :(=) || kw.head == :kw || combinefun == true
         membernames = Dict{Any, Symbol}()
-        funname = gensym()
         if combinefun == false
             body = replace_syms!(kw.args[2], membernames)
         else
@@ -108,17 +107,13 @@ function fun_to_vec(kw::Expr; combinefun = false)
             output = kw.args[1]
             t = quote
                 $(Expr(:vect, keys(membernames)...)) =>
-                (function $funname($(values(membernames)...))
-                    $body
-                end) =>
+                ($(Expr(:tuple, values(membernames)...)) -> $body) =>
                 $(QuoteNode(output))
             end
         else
             t = quote
                 $(Expr(:vect, keys(membernames)...)) =>
-                (function $funname($(values(membernames)...))
-                    $body
-                end)
+                ($(Expr(:tuple, values(membernames)...)) -> $body)
             end
         end
         return t

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -116,7 +116,7 @@ function fun_to_vec(kw::Expr; nolhs = false)
             t = quote
                 $(Expr(:vect, keys(membernames)...)) =>
                 ($(Expr(:tuple, values(membernames)...)) -> $body) =>
-                $(output)
+                $(QuoteNode(output))
             end
         end
         return t

--- a/src/byrow.jl
+++ b/src/byrow.jl
@@ -34,7 +34,7 @@ function byrow_find_newcols(e::Expr, newcol_decl)
     if e.head == :macrocall && e.args[1] == Symbol("@newcol")
         ea = e.args[3]
         # expression to assign a new column to df
-        return (nothing, Any[Expr(:kw, ea.args[1], Expr(:call, ea.args[2], :undef, :_N))])
+        return (nothing, Any[Expr(:(=), ea.args[1], Expr(:call, ea.args[2], :undef, :_N))])
     else
         if isempty(e.args)
             return (e.args, Any[])
@@ -99,8 +99,8 @@ by `@byrow`. Also note that the returned data frame does not share columns
 with `d`.
 
 Like with `@transform`, `@byrow` supports the use of `cols` to work with column names
-stored as variables. Using `cols` with a multi-column selector, such as a `Vector` of 
-`Symbol`s, is currently unsupported. 
+stored as variables. Using `cols` with a multi-column selector, such as a `Vector` of
+`Symbol`s, is currently unsupported.
 
 ### Arguments
 
@@ -151,7 +151,7 @@ julia> df2 = @byrow df begin
 │ 2   │ 0 │ 1 │ 1.0     │
 │ 3   │ 0 │ 2 │ 0.0     │
 
-julia> varA = :A; varB = :B; 
+julia> varA = :A; varB = :B;
 
 julia> df2 = @byrow df begin
            @newcol colX::Array{Float64}

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -424,20 +424,18 @@ df = DataFrame(
     t = ["a", "b", "c", "c", "e"],
     y = [:v, :w, :x, :y, :z],
     c = [:g, :quote, :body, :transform, missing]
-    )
+)
     
 @testset "limits of @cols and @row" begin
     @test_throws MethodError @eval DataFrames.transform(df, @col n = sum(All()))
     @test_throws MethodError @eval DataFrames.transform(df, @col n = sum(Between(:g, :i)))
     @test_throws MethodError @eval DataFrames.transform(df, @col n = sum(Not([:t, :y, :c])))
     @test_throws ArgumentError @eval DataFrames.transform(df, @col n = sum(cols([:g, :i])))
-    @test_throws UndefError @eval DataFrames.transform(df, @col n = g)
 
-    @test_throws MethodError @eval DataFrames.transform(df, @row n = sum(All()))
+    @test_throws ArgumentError @eval DataFrames.transform(df, @row n = sum(All()))
     @test_throws MethodError @eval DataFrames.transform(df, @row n = sum(Between(:g, :i)))
     @test_throws MethodError @eval DataFrames.transform(df, @row n = sum(Not([:t, :y, :c])))
     @test_throws ArgumentError @eval DataFrames.transform(df, @row n = sum(cols([:g, :i])))
-    @test_throws UndefError @eval DataFrames.transform(df, @row n = g)
 end
 
 end # module

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -62,6 +62,8 @@ const ≅ = isequal
 
     @test @transform(df, :i) ≅ df
     @test @transform(df, :i, :g) ≅ df
+
+    @test @transform(df, :n = 1).n == fill(1, nrow(df))
 end
 
 # Defined outside of `@testset` due to use of `@eval`
@@ -161,6 +163,8 @@ end
     @test @select(df, transform = cols(ir)).transform == df.i
 
     @test DataFramesMeta.select(df, :i) == df.i
+
+    @test @select(df, :n = 1).n == fill(1, nrow(df))
 end
 
 # Defined outside of `@testset` due to use of `@eval`

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -312,4 +312,132 @@ df = DataFrame(A = 1:3, B = [2, 1, 2])
     @test_throws ArgumentError @eval @byrow df begin cols(n) end    
 end
 
+@testset "@col" begin
+    df = DataFrame(
+        g = [1, 1, 1, 2, 2],
+        i = 1:5, 
+        t = ["a", "b", "c", "c", "e"],
+        y = [:v, :w, :x, :y, :z],
+        c = [:g, :quote, :body, :transform, missing]
+        )
+    
+    m = [100, 200, 300, 400, 500]
+    
+    gq = :g
+    iq = :i
+    tq = :t
+    yq = :y
+    cq = :c
+    
+    gr = "g"
+    ir = "i"
+    tr = "t"
+    yr = "y"
+    cr = "c"
+
+    nname = :n
+
+    @test DataFrames.transform(df, @col n = :i).n == df.i
+    @test DataFrames.transform(df, @col n = :i .+ :g).n == df.i .+ df.g
+    @test DataFrames.transform(df, @col n = :t .* string.(:y)).n == df.t .* string.(df.y)
+    @test DataFrames.transform(df, @col n = Symbol.(:y, ^(:t))).n == Symbol.(df.y, :t)
+    @test DataFrames.transform(df, @col n = Symbol.(:y, ^(:body))).n == Symbol.(df.y, :body)
+    @test DataFrames.transform(df, @col body = :i).body == df.i 
+    @test DataFrames.transform(df, @col transform = :i).transform == df.i    
+
+    @test DataFrames.transform(df, @col n = cols(iq)).n == df.i
+    @test DataFrames.transform(df, @col n = cols(iq) .+ cols(gq)).n == df.i .+ df.g
+    @test DataFrames.transform(df, @col n = cols(tq) .* string.(cols(yq))).n == df.t .* string.(df.y)
+    @test DataFrames.transform(df, @col n = Symbol.(cols(yq), ^(:t))).n == Symbol.(df.y, :t)
+    @test DataFrames.transform(df, @col n = Symbol.(cols(yq), ^(:body))).n == Symbol.(df.y, :body)
+    @test DataFrames.transform(df, @col body = cols(iq)).body == df.i 
+    @test DataFrames.transform(df, @col transform = cols(iq)).transform == df.i
+    
+    @test DataFrames.transform(df, @col n = cols(ir)).n == df.i
+    @test DataFrames.transform(df, @col n = cols(ir) .+ cols(gr)).n == df.i .+ df.g
+    @test DataFrames.transform(df, @col n = cols(tr) .* string.(cols(yr))).n == df.t .* string.(df.y)
+    @test DataFrames.transform(df, @col n = Symbol.(cols(yr), ^(:t))).n == Symbol.(df.y, :t)
+    @test DataFrames.transform(df, @col n = Symbol.(cols(yr), ^(:body))).n == Symbol.(df.y, :body)
+    @test DataFrames.transform(df, @col body = cols(ir)).body == df.i 
+
+    @test DataFrames.transform(df, @col cols(nname) = :i).n == df.i
+    @test DataFrames.transform(df, @col cols("body") = :i).body == df.i 
+    @test DataFrames.transform(df, @col cols(:transform) = :i).transform == df.i   
+end
+
+@testset "@row" begin
+    df = DataFrame(
+        g = [1, 1, 1, 2, 2],
+        i = 1:5, 
+        t = ["a", "b", "c", "c", "e"],
+        y = [:v, :w, :x, :y, :z],
+        c = [:g, :quote, :body, :transform, missing]
+        )
+    
+    m = [100, 200, 300, 400, 500]
+    
+    gq = :g
+    iq = :i
+    tq = :t
+    yq = :y
+    cq = :c
+    
+    gr = "g"
+    ir = "i"
+    tr = "t"
+    yr = "y"
+    cr = "c"
+
+    nname = :n
+
+    @test DataFrames.transform(df, @row n = :i).n == df.i
+    @test DataFrames.transform(df, @row n = :i + :g).n == df.i .+ df.g
+    @test DataFrames.transform(df, @row n = :t * string(:y)).n == df.t .* string.(df.y)
+    @test DataFrames.transform(df, @row n = Symbol(:y, ^(:t))).n == Symbol.(df.y, :t)
+    @test DataFrames.transform(df, @row n = Symbol(:y, ^(:body))).n == Symbol.(df.y, :body)
+    @test DataFrames.transform(df, @row body = :i).body == df.i 
+    @test DataFrames.transform(df, @row transform = :i).transform == df.i    
+
+    @test DataFrames.transform(df, @row n = cols(iq)).n == df.i
+    @test DataFrames.transform(df, @row n = cols(iq) + cols(gq)).n == df.i .+ df.g
+    @test DataFrames.transform(df, @row n = cols(tq) * string.(cols(yq))).n == df.t .* string.(df.y)
+    @test DataFrames.transform(df, @row n = Symbol(cols(yq), ^(:t))).n == Symbol.(df.y, :t)
+    @test DataFrames.transform(df, @row n = Symbol(cols(yq), ^(:body))).n == Symbol.(df.y, :body)
+    @test DataFrames.transform(df, @row body = cols(iq)).body == df.i 
+    @test DataFrames.transform(df, @row transform = cols(iq)).transform == df.i
+    
+    @test DataFrames.transform(df, @row n = cols(ir)).n == df.i
+    @test DataFrames.transform(df, @row n = cols(ir) + cols(gr)).n == df.i .+ df.g
+    @test DataFrames.transform(df, @row n = cols(tr) * string.(cols(yr))).n == df.t .* string.(df.y)
+    @test DataFrames.transform(df, @row n = Symbol(cols(yr), ^(:t))).n == Symbol.(df.y, :t)
+    @test DataFrames.transform(df, @row n = Symbol(cols(yr), ^(:body))).n == Symbol.(df.y, :body)
+    @test DataFrames.transform(df, @row body = cols(ir)).body == df.i 
+
+    @test DataFrames.transform(df, @row cols(nname) = :i).n == df.i
+    @test DataFrames.transform(df, @row cols("body") = :i).body == df.i 
+    @test DataFrames.transform(df, @row cols(:transform) = :i).transform == df.i   
+end
+
+df = DataFrame(
+    g = [1, 1, 1, 2, 2],
+    i = 1:5, 
+    t = ["a", "b", "c", "c", "e"],
+    y = [:v, :w, :x, :y, :z],
+    c = [:g, :quote, :body, :transform, missing]
+    )
+    
+@testset "limits of @cols and @row" begin
+    @test_throws MethodError @eval DataFrames.transform(df, @col n = sum(All()))
+    @test_throws MethodError @eval DataFrames.transform(df, @col n = sum(Between(:g, :i)))
+    @test_throws MethodError @eval DataFrames.transform(df, @col n = sum(Not([:t, :y, :c])))
+    @test_throws ArgumentError @eval DataFrames.transform(df, @col n = sum(cols([:g, :i])))
+    @test_throws UndefError @eval DataFrames.transform(df, @col n = g)
+
+    @test_throws MethodError @eval DataFrames.transform(df, @row n = sum(All()))
+    @test_throws MethodError @eval DataFrames.transform(df, @row n = sum(Between(:g, :i)))
+    @test_throws MethodError @eval DataFrames.transform(df, @row n = sum(Not([:t, :y, :c])))
+    @test_throws ArgumentError @eval DataFrames.transform(df, @row n = sum(cols([:g, :i])))
+    @test_throws UndefError @eval DataFrames.transform(df, @row n = g)
+end
+
 end # module

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -63,7 +63,7 @@ const ≅ = isequal
     @test @transform(df, :i) ≅ df
     @test @transform(df, :i, :g) ≅ df
 
-    @test @transform(df, :n = 1).n == fill(1, nrow(df))
+    @test @transform(df, n = 1).n == fill(1, nrow(df))
 end
 
 # Defined outside of `@testset` due to use of `@eval`
@@ -164,7 +164,7 @@ end
 
     @test DataFramesMeta.select(df, :i) == df.i
 
-    @test @select(df, :n = 1).n == fill(1, nrow(df))
+    @test @select(df, n = 1).n == fill(1, nrow(df))
 end
 
 # Defined outside of `@testset` due to use of `@eval`

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -97,6 +97,9 @@ s = [:i, :g]
     # should throw an `ArgumentError`. Regardless,
     # the following should error so these tests are
     # left in.
+    #
+    # This behavior is part of `@test_throws` and
+    # not part of DataFramesMeta.
     @test_throws LoadError @eval @transform(df, [:i, :g])
     @test_throws LoadError @eval @transform(df, All())
     @test_throws LoadError @eval @transform(df, Between(:i, :t)).Between == df.i

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -100,7 +100,7 @@ s = [:i, :g]
     @test_throws LoadError @eval @transform(df, [:i, :g])
     @test_throws LoadError @eval @transform(df, All())
     @test_throws LoadError @eval @transform(df, Between(:i, :t)).Between == df.i
-    @test_throws LoadError @eval  @transform(df, Not(:i)).Not == df.i
+    @test_throws LoadError @eval @transform(df, Not(:i)).Not == df.i
     @test_throws LoadError @eval @transform(df, Not([:i, :g]))
     newvar = :n
     @test_throws ArgumentError @eval @transform(df, cols(newvar) = :i)

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -11,20 +11,20 @@ const ≅ = isequal
 @testset "@transform" begin
     df = DataFrame(
         g = [1, 1, 1, 2, 2],
-        i = 1:5, 
+        i = 1:5,
         t = ["a", "b", "c", "c", "e"],
         y = [:v, :w, :x, :y, :z],
         c = [:g, :quote, :body, :transform, missing]
         )
-    
+
     m = [100, 200, 300, 400, 500]
-    
+
     gq = :g
     iq = :i
     tq = :t
     yq = :y
     cq = :c
-    
+
     gr = "g"
     ir = "i"
     tr = "t"
@@ -36,23 +36,23 @@ const ≅ = isequal
     @test @transform(df, n = :t .* string.(:y)).n == df.t .* string.(df.y)
     @test @transform(df, n = Symbol.(:y, ^(:t))).n == Symbol.(df.y, :t)
     @test @transform(df, n = Symbol.(:y, ^(:body))).n == Symbol.(df.y, :body)
-    @test @transform(df, body = :i).body == df.i 
+    @test @transform(df, body = :i).body == df.i
     @test @transform(df, transform = :i).transform == df.i
-    
+
     @test @transform(df, n = cols(iq)).n == df.i
     @test @transform(df, n = cols(iq) .+ cols(gq)).n == df.i .+ df.g
     @test @transform(df, n = cols(tq) .* string.(cols(yq))).n == df.t .* string.(df.y)
     @test @transform(df, n = Symbol.(cols(yq), ^(:t))).n == Symbol.(df.y, :t)
     @test @transform(df, n = Symbol.(cols(yq), ^(:body))).n == Symbol.(df.y, :body)
-    @test @transform(df, body = cols(iq)).body == df.i 
+    @test @transform(df, body = cols(iq)).body == df.i
     @test @transform(df, transform = cols(iq)).transform == df.i
-    
+
     @test @transform(df, n = cols(ir)).n == df.i
     @test @transform(df, n = cols(ir) .+ cols(gr)).n == df.i .+ df.g
     @test @transform(df, n = cols(tr) .* string.(cols(yr))).n == df.t .* string.(df.y)
     @test @transform(df, n = Symbol.(cols(yr), ^(:t))).n == Symbol.(df.y, :t)
     @test @transform(df, n = Symbol.(cols(yr), ^(:body))).n == Symbol.(df.y, :body)
-    @test @transform(df, body = cols(ir)).body == df.i 
+    @test @transform(df, body = cols(ir)).body == df.i
     @test @transform(df, transform = cols(ir)).transform == df.i
 
     @test @transform(df, n = :i).g !== df.g
@@ -64,7 +64,7 @@ end
 # Defined outside of `@testset` due to use of `@eval`
 df = DataFrame(
     g = [1, 1, 1, 2, 2],
-    i = 1:5, 
+    i = 1:5,
     t = ["a", "b", "c", "c", "e"],
     y = [:v, :w, :x, :y, :z],
     c = [:g, :quote, :body, :transform, missing]
@@ -88,37 +88,33 @@ s = [:i, :g]
 
 @testset "limits of @transform" begin
     ## Test for not-implemented or strange behavior
-    @test_throws LoadError @eval @transform(df, :i)
     @test_throws ErrorException @eval @transform(df, [:i, :g])
     @test_throws LoadError @eval @transform(df, All())
-    @test @transform(df, Between(:i, :t)).Between == df.i
-    @test @transform(df, Not(:i)).Not == df.i
     @test_throws ArgumentError @eval @transform(df, Not([:i, :g]))
     newvar = :n
     @test_throws ErrorException @eval @transform(df, cols(newvar) = :i)
     @test_throws MethodError @eval @transform(df, n = sum(Between(:i, :t)))
     @test @transform(df, n = :i).n === df.i
-    @test @transform(df, n = cols(s).i).n == df.i
 end
 
 @testset "@select" begin
     # Defined outside of `@testset` due to use of `@eval`
     df = DataFrame(
         g = [1, 1, 1, 2, 2],
-        i = 1:5, 
+        i = 1:5,
         t = ["a", "b", "c", "c", "e"],
         y = [:v, :w, :x, :y, :z],
         c = [:g, :quote, :body, :transform, missing]
         )
-    
+
     m = [100, 200, 300, 400, 500]
-    
+
     gq = :g
     iq = :i
     tq = :t
     yq = :y
     cq = :c
-    
+
     gr = "g"
     ir = "i"
     tr = "t"
@@ -136,23 +132,23 @@ end
     @test @select(df, n = :t .* string.(:y)).n == df.t .* string.(df.y)
     @test @select(df, n = Symbol.(:y, ^(:t))).n == Symbol.(df.y, :t)
     @test @select(df, n = Symbol.(:y, ^(:body))).n == Symbol.(df.y, :body)
-    @test @select(df, body = :i).body == df.i 
+    @test @select(df, body = :i).body == df.i
     @test @select(df, transform = :i).transform == df.i
-    
+
     @test @select(df, n = cols(iq)).n == df.i
     @test @select(df, n = cols(iq) .+ cols(gq)).n == df.i .+ df.g
     @test @select(df, n = cols(tq) .* string.(cols(yq))).n == df.t .* string.(df.y)
     @test @select(df, n = Symbol.(cols(yq), ^(:t))).n == Symbol.(df.y, :t)
     @test @select(df, n = Symbol.(cols(yq), ^(:body))).n == Symbol.(df.y, :body)
-    @test @select(df, body = cols(iq)).body == df.i 
+    @test @select(df, body = cols(iq)).body == df.i
     @test @select(df, transform = cols(iq)).transform == df.i
-    
+
     @test @select(df, n = cols(ir)).n == df.i
     @test @select(df, n = cols(ir) .+ cols(gr)).n == df.i .+ df.g
     @test @select(df, n = cols(tr) .* string.(cols(yr))).n == df.t .* string.(df.y)
     @test @select(df, n = Symbol.(cols(yr), ^(:t))).n == Symbol.(df.y, :t)
     @test @select(df, n = Symbol.(cols(yr), ^(:body))).n == Symbol.(df.y, :body)
-    @test @select(df, body = cols(ir)).body == df.i 
+    @test @select(df, body = cols(ir)).body == df.i
     @test @select(df, transform = cols(ir)).transform == df.i
 
     @test DataFramesMeta.select(df, :i) == df.i
@@ -161,7 +157,7 @@ end
 # Defined outside of `@testset` due to use of `@eval`
 df = DataFrame(
     g = [1, 1, 1, 2, 2],
-    i = 1:5, 
+    i = 1:5,
     t = ["a", "b", "c", "c", "e"],
     y = [:v, :w, :x, :y, :z],
     c = [:g, :quote, :body, :transform, missing]
@@ -201,13 +197,13 @@ end
 
 @testset "with" begin
     df = DataFrame(A = 1:3, B = [2, 1, 2])
-    
+
     x = [2, 1, 0]
-    
+
     @test  @with(df, :A .+ 1)   ==  df.A .+ 1
     @test  @with(df, :A .+ :B)  ==  df.A .+ df.B
     @test  @with(df, :A .+ x)   ==  df.A .+ x
-    
+
     x = @with df begin
         res = 0.0
         for i in 1:length(:A)
@@ -219,7 +215,7 @@ end
     @test  @with(df, cols(idx) .+ :B)  ==  df.A .+ df.B
     idx2 = :B
     @test  @with(df, cols(idx) .+ cols(idx2))  ==  df.A .+ df.B
-    
+
     @test  x == sum(df.A .* df.B)
     @test  @with(df, df[:A .> 1, ^([:B, :A])]) == df[df.A .> 1, [:B, :A]]
     @test  @with(df, DataFrame(a = :A * 2, b = :A .+ :B)) == DataFrame(a = df.A * 2, b = df.A .+ df.B)
@@ -231,7 +227,7 @@ end
     x = [2, 1, 0]
 
     @test DataFramesMeta.where(df, 1) == df[1, :]
-    
+
     @test  @where(df, :A .> 1)          == df[df.A .> 1,:]
     @test  @where(df, :B .> 1)          == df[df.B .> 1,:]
     @test  @where(df, :A .> x)          == df[df.A .> x,:]
@@ -273,7 +269,7 @@ y = 0
             :colY = :A * :B
         end
     end
-        
+
     @test  df2.colX == [pi, 1.0, 3pi]
     @test  df2[2, :colY] == 2
 end
@@ -309,26 +305,26 @@ df = DataFrame(A = 1:3, B = [2, 1, 2])
     @test_throws ArgumentError @eval @byrow df begin cols(n) end
 
     @eval TestDataFrames n = [1, 2]
-    @test_throws ArgumentError @eval @byrow df begin cols(n) end    
+    @test_throws ArgumentError @eval @byrow df begin cols(n) end
 end
 
 @testset "@col" begin
     df = DataFrame(
         g = [1, 1, 1, 2, 2],
-        i = 1:5, 
+        i = 1:5,
         t = ["a", "b", "c", "c", "e"],
         y = [:v, :w, :x, :y, :z],
         c = [:g, :quote, :body, :transform, missing]
         )
-    
+
     m = [100, 200, 300, 400, 500]
-    
+
     gq = :g
     iq = :i
     tq = :t
     yq = :y
     cq = :c
-    
+
     gr = "g"
     ir = "i"
     tr = "t"
@@ -342,46 +338,46 @@ end
     @test DataFrames.transform(df, @col n = :t .* string.(:y)).n == df.t .* string.(df.y)
     @test DataFrames.transform(df, @col n = Symbol.(:y, ^(:t))).n == Symbol.(df.y, :t)
     @test DataFrames.transform(df, @col n = Symbol.(:y, ^(:body))).n == Symbol.(df.y, :body)
-    @test DataFrames.transform(df, @col body = :i).body == df.i 
-    @test DataFrames.transform(df, @col transform = :i).transform == df.i    
+    @test DataFrames.transform(df, @col body = :i).body == df.i
+    @test DataFrames.transform(df, @col transform = :i).transform == df.i
 
     @test DataFrames.transform(df, @col n = cols(iq)).n == df.i
     @test DataFrames.transform(df, @col n = cols(iq) .+ cols(gq)).n == df.i .+ df.g
     @test DataFrames.transform(df, @col n = cols(tq) .* string.(cols(yq))).n == df.t .* string.(df.y)
     @test DataFrames.transform(df, @col n = Symbol.(cols(yq), ^(:t))).n == Symbol.(df.y, :t)
     @test DataFrames.transform(df, @col n = Symbol.(cols(yq), ^(:body))).n == Symbol.(df.y, :body)
-    @test DataFrames.transform(df, @col body = cols(iq)).body == df.i 
+    @test DataFrames.transform(df, @col body = cols(iq)).body == df.i
     @test DataFrames.transform(df, @col transform = cols(iq)).transform == df.i
-    
+
     @test DataFrames.transform(df, @col n = cols(ir)).n == df.i
     @test DataFrames.transform(df, @col n = cols(ir) .+ cols(gr)).n == df.i .+ df.g
     @test DataFrames.transform(df, @col n = cols(tr) .* string.(cols(yr))).n == df.t .* string.(df.y)
     @test DataFrames.transform(df, @col n = Symbol.(cols(yr), ^(:t))).n == Symbol.(df.y, :t)
     @test DataFrames.transform(df, @col n = Symbol.(cols(yr), ^(:body))).n == Symbol.(df.y, :body)
-    @test DataFrames.transform(df, @col body = cols(ir)).body == df.i 
+    @test DataFrames.transform(df, @col body = cols(ir)).body == df.i
 
     @test DataFrames.transform(df, @col cols(nname) = :i).n == df.i
-    @test DataFrames.transform(df, @col cols("body") = :i).body == df.i 
-    @test DataFrames.transform(df, @col cols(:transform) = :i).transform == df.i   
+    @test DataFrames.transform(df, @col cols("body") = :i).body == df.i
+    @test DataFrames.transform(df, @col cols(:transform) = :i).transform == df.i
 end
 
 @testset "@row" begin
     df = DataFrame(
         g = [1, 1, 1, 2, 2],
-        i = 1:5, 
+        i = 1:5,
         t = ["a", "b", "c", "c", "e"],
         y = [:v, :w, :x, :y, :z],
         c = [:g, :quote, :body, :transform, missing]
         )
-    
+
     m = [100, 200, 300, 400, 500]
-    
+
     gq = :g
     iq = :i
     tq = :t
     yq = :y
     cq = :c
-    
+
     gr = "g"
     ir = "i"
     tr = "t"
@@ -395,37 +391,37 @@ end
     @test DataFrames.transform(df, @row n = :t * string(:y)).n == df.t .* string.(df.y)
     @test DataFrames.transform(df, @row n = Symbol(:y, ^(:t))).n == Symbol.(df.y, :t)
     @test DataFrames.transform(df, @row n = Symbol(:y, ^(:body))).n == Symbol.(df.y, :body)
-    @test DataFrames.transform(df, @row body = :i).body == df.i 
-    @test DataFrames.transform(df, @row transform = :i).transform == df.i    
+    @test DataFrames.transform(df, @row body = :i).body == df.i
+    @test DataFrames.transform(df, @row transform = :i).transform == df.i
 
     @test DataFrames.transform(df, @row n = cols(iq)).n == df.i
     @test DataFrames.transform(df, @row n = cols(iq) + cols(gq)).n == df.i .+ df.g
     @test DataFrames.transform(df, @row n = cols(tq) * string.(cols(yq))).n == df.t .* string.(df.y)
     @test DataFrames.transform(df, @row n = Symbol(cols(yq), ^(:t))).n == Symbol.(df.y, :t)
     @test DataFrames.transform(df, @row n = Symbol(cols(yq), ^(:body))).n == Symbol.(df.y, :body)
-    @test DataFrames.transform(df, @row body = cols(iq)).body == df.i 
+    @test DataFrames.transform(df, @row body = cols(iq)).body == df.i
     @test DataFrames.transform(df, @row transform = cols(iq)).transform == df.i
-    
+
     @test DataFrames.transform(df, @row n = cols(ir)).n == df.i
     @test DataFrames.transform(df, @row n = cols(ir) + cols(gr)).n == df.i .+ df.g
     @test DataFrames.transform(df, @row n = cols(tr) * string.(cols(yr))).n == df.t .* string.(df.y)
     @test DataFrames.transform(df, @row n = Symbol(cols(yr), ^(:t))).n == Symbol.(df.y, :t)
     @test DataFrames.transform(df, @row n = Symbol(cols(yr), ^(:body))).n == Symbol.(df.y, :body)
-    @test DataFrames.transform(df, @row body = cols(ir)).body == df.i 
+    @test DataFrames.transform(df, @row body = cols(ir)).body == df.i
 
     @test DataFrames.transform(df, @row cols(nname) = :i).n == df.i
-    @test DataFrames.transform(df, @row cols("body") = :i).body == df.i 
-    @test DataFrames.transform(df, @row cols(:transform) = :i).transform == df.i   
+    @test DataFrames.transform(df, @row cols("body") = :i).body == df.i
+    @test DataFrames.transform(df, @row cols(:transform) = :i).transform == df.i
 end
 
 df = DataFrame(
     g = [1, 1, 1, 2, 2],
-    i = 1:5, 
+    i = 1:5,
     t = ["a", "b", "c", "c", "e"],
     y = [:v, :w, :x, :y, :z],
     c = [:g, :quote, :body, :transform, missing]
 )
-    
+
 @testset "limits of @cols and @row" begin
     @test_throws MethodError @eval DataFrames.transform(df, @col n = sum(All()))
     @test_throws MethodError @eval DataFrames.transform(df, @col n = sum(Between(:g, :i)))

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -222,9 +222,9 @@ end
 	d = DataFrame(a = [1,1,1,2,2,3,3,1],
 	              b = Any[1,2,3,missing,missing,6.0,5.0,4],
 	              c = CategoricalArray([1,2,3,1,2,3,1,2]))
-    g = groupby(d, :a)
+      g = groupby(d, :a)
 
-    ## Scalar output
+      ## Scalar output
 	# Type promotion Int -> Float
 	t = @transform(g, t = :b[1]).t
 	@test isequal(t, [1.0, 1.0, 1.0, 1.0, missing, missing, 6.0, 6.0]) &&

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -222,9 +222,9 @@ end
 	d = DataFrame(a = [1,1,1,2,2,3,3,1],
 	              b = Any[1,2,3,missing,missing,6.0,5.0,4],
 	              c = CategoricalArray([1,2,3,1,2,3,1,2]))
-
     g = groupby(d, :a)
-	## Scalar output
+
+    ## Scalar output
 	# Type promotion Int -> Float
 	t = @transform(g, t = :b[1]).t
 	@test isequal(t, [1.0, 1.0, 1.0, 1.0, missing, missing, 6.0, 6.0]) &&

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -213,12 +213,13 @@ end
 	d = DataFrame(n = 1:20, x = [3, 3, 3, 3, 1, 1, 1, 2, 1, 1, 2, 1, 1, 2, 2, 2, 3, 1, 1, 2])
 	g = groupby(d, :x, sort=true)
 
-	@test  (@transform(g, y = :n .- median(:n)))[1,:y] == -5.0
+	@test (@transform(g, y = :n .- median(:n)))[1,:y] == -5.0
 
 	d = DataFrame(a = [1,1,1,2,2,3,3,1],
 	              b = Any[1,2,3,missing,missing,6.0,5.0,4],
 	              c = CategoricalArray([1,2,3,1,2,3,1,2]))
-	g = groupby(d, :a)
+
+    g = groupby(d, :a)
 	## Scalar output
 	# Type promotion Int -> Float
 	t = @transform(g, t = :b[1]).t

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -77,7 +77,7 @@ g = groupby(d, :x, sort=true)
     @test @based_on(gd, :i).i == df.i
     @test @based_on(gd,:i, :g).g == df.g
 
-    @test @based_on(gd, :i, :n = 1).n == fill(1, nrow(df))
+    @test @based_on(gd, :i, n = 1).n == fill(1, nrow(df))
 end
 
 # Defined outside of `@testset` due to use of `@eval`
@@ -173,7 +173,7 @@ end
     @test @by(df, :g, :i).i == df.i
     @test @by(df, :g, :i, :g).g == df.g
 
-    @test @by(df, :g, :i, :n = 1).n == fill(1, nrow(df))
+    @test @by(df, :g, :i, n = 1).n == fill(1, nrow(df))
 end
 
 # Defined outside of `@testset` due to use of `@eval`

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -75,7 +75,7 @@ g = groupby(d, :x, sort=true)
     @test @based_on(gd, (n1 = [first(cols(ir))], n2 = [first(cols(yr))])).n1 == [1, 4]
 
     @test @based_on(gd, :i).i == df.i
-    @test @based_on(gd,:i, :g).g == df.g
+    @test @based_on(gd, :i, :g).g == df.g
 
     @test @based_on(gd, :i, n = 1).n == fill(1, nrow(df))
 end

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -74,8 +74,8 @@ g = groupby(d, :x, sort=true)
     @test @based_on(gd, transform = cols(ir)).transform == df.i
     @test @based_on(gd, (n1 = [first(cols(ir))], n2 = [first(cols(yr))])).n1 == [1, 4]
 
-    @test @based_on(gd, :i).i == df.i
-    @test @based_on(gd, :i, :g).g == df.g
+    @test @based_on(gd, :i) == select(df, :g, :i)
+    @test @based_on(gd, :i, :g) ≅ select(df, :g, :i)
 
     @test @based_on(gd, :i, n = 1).n == fill(1, nrow(df))
 end
@@ -108,7 +108,9 @@ gd = groupby(df, :g)
 newvar = :n
 
 @testset "Limits of @based_on" begin
-    @test @based_on(gd, [:i, :g]).i_g_function isa Vector{<:SubArray}
+    t = @based_on(gd, [:i, :g]).i_g_function
+    @test t == [[1, 2, 3], [1, 1, 1], [4, 5], [2, 2]]
+    @test t isa Vector{SubArray{Int64,1,Array{Int64,1},Tuple{Array{Int64,1}},false}}
     @test @based_on(gd, All()).function isa Vector{<:All}
     @test @based_on(gd, Not(:i)).i_function isa Vector{<:InvertedIndex}
     @test @based_on(gd, Not([:i, :g])).g == [1, 2]
@@ -170,8 +172,8 @@ end
     @test @by(df, "g", transform = cols(ir)).transform == df.i
     @test @by(df, "g", (n1 = [first(cols(ir))], n2 = [first(cols(yr))])).n1 == [1, 4]
 
-    @test @by(df, :g, :i).i == df.i
-    @test @by(df, :g, :i, :g).g == df.g
+    @test @by(df, :g, :i) == select(df, :g, :i)
+    @test @by(df, :g, :i, :g) ≅ select(df, :g, :i)
 
     @test @by(df, :g, :i, n = 1).n == fill(1, nrow(df))
 end
@@ -204,7 +206,9 @@ gd = groupby(df, :g)
 newvar = :n
 
 @testset "limits of @by" begin
-    @test @by(df, :g, [:i, :g]).i_g_function isa Vector{<:SubArray}
+    t = @by(df, :g, [:i, :g]).i_g_function
+    @test t == [[1, 2, 3], [1, 1, 1], [4, 5], [2, 2]]
+    @test t isa Vector{SubArray{Int64,1,Array{Int64,1},Tuple{Array{Int64,1}},false}}
     @test @by(df, :g, All()).function isa Vector{<:All}
     @test @by(df, :g, Not(:i)).i_function isa Vector{<:InvertedIndex}
     @test @by(df, :g, Not([:i, :g])).g == [1, 2]

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -76,6 +76,8 @@ g = groupby(d, :x, sort=true)
 
     @test @based_on(gd, :i).i == df.i
     @test @based_on(gd,:i, :g).g == df.g
+
+    @test @based_on(gd, :i, :n = 1).n == fill(1, nrow(df))
 end
 
 # Defined outside of `@testset` due to use of `@eval`
@@ -170,6 +172,8 @@ end
 
     @test @by(df, :g, :i).i == df.i
     @test @by(df, :g, :i, :g).g == df.g
+
+    @test @by(df, :g, :i, :n = 1).n == fill(1, nrow(df))
 end
 
 # Defined outside of `@testset` due to use of `@eval`


### PR DESCRIPTION
This is obviously inspired by [DataFramesMacros](https://github.com/matthieugomez/DataFramesMacros.jl) from @matthieugomez.

This PR introduces two macros, `@col` and `@row`. Here is the docstring introducting their behavior. 

    @col(kw)

    
`@col` transforms an expression of the form `z = :x + :y` into it's equivalent in 
DataFrames's "mini-language". Functions act column-wise. For a row-wise functions, see 
`@row`

### Details

Parsing follows the same convention as other DataFramesMeta macros, such as `@with`. All 
terms in the expression that are `Symbols` are treated as columns in the DataFrame, except 
`Symbol`s wrapped in `^`. To use a variable representing a column name, wrap the variable 
in `cols`. 

`@col` constructs an anonymous function based off the given expression. It then creates
a `source => fun => destination` pair that is suitable for the `select`, `transform`, and 
`combine` functions in DataFrames. 

### Examples

```
julia> @col z = :x + :y
[:x, :y] => (##595 => :z)
```

In the above example, `##595` is an anonymous function equivelent to the following 

```
(_x, _y) -> _x + _y
```

```
julia> df = DataFrame(x = [1, 2], y = [3, 4]);

julia> DataFrames.transform(df, @col z = :x .* :y)
2×3 DataFrame
│ Row │ x     │ y     │ z     │
│     │ Int64 │ Int64 │ Int64 │
├─────┼───────┼───────┼───────┤
│ 1   │ 1     │ 3     │ 3     │
│ 2   │ 2     │ 4     │ 8     │

julia> DataFrames.transform(df, [:x, :y] => ((_x, _y) -> _x .* _y) => :z)
2×3 DataFrame
│ Row │ x     │ y     │ z     │
│     │ Int64 │ Int64 │ Int64 │
├─────┼───────┼───────┼───────┤
│ 1   │ 1     │ 3     │ 3     │
│ 2   │ 2     │ 4     │ 8     │

```

This PR represents the initial step in having `DataFrames.transform`,  `DataFrames.select`, and `DataFrames.combine` be the backend for most DataFramesMeta functionality. In the future, these macros, or, the function that transform the expressions in these macros, will transform all inputs to `@transform` etc. 

Design decisions left to discuss

1. Many people have expressed interest in not forcing people to write `:x` and instead write `x` for `df.x`, similar to `dplyr` and Stata (`@transform(z = x + y)`). I support this, conditional on air-tight escaping rules. Should we start that transition now in the development of these macros?
2. Naming. Obviously `@col` is a less-than-ideal name given `Cols()` in DataAPI and `cols` for variable escaping. We should bikeshed over the name a bit. 
3. Multi-column selectors are broken for the time being, given you can't do `DataFrames.transform(df, [:x, [:y, :z]] => fun => :a)`. See discussions in [DataFrames](https://github.com/JuliaData/DataFrames.jl/issues/2328) and [DataFramesMeta](https://github.com/JuliaData/DataFramesMeta.jl/pull/157). 

I think this is a solid first step!

cc @bkamins, @nalimilan, @matthieugomez

cc DataFramesMeta users @tk3369

