### PR TITLE
Allow cols on LHS

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ end
 ## Working with column names programmatically with `cols`
 
 DataFramesMeta provides the special syntax, `cols`, for referring to 
-columns in a DataFrame via a `Symbol`, `String`, or column position. 
+columns in a data frame via a `Symbol`, string, or column position as either
+a literal or a variable. 
 
 ```julia
-
 df = DataFrame(A = 1:3, B = [2, 1, 2])
 
 nameA = :A
@@ -140,10 +140,9 @@ nameB = "B"
 df3 = @byrow df begin 
     :A = cols(nameB)
 end
-
 ```
 
-`cols` can also be used to create new columns in a DataFrame. 
+`cols` can also be used to create new columns in a data frame. 
 
 ```julia
 df = DataFrame(A = 1:3, B = [2, 1, 2])
@@ -158,11 +157,11 @@ df3 = @byrow df begin
     @newcol cols(nameC)::Vector{Int}
     cols(nameC) = :A
 end
-
 ```
 
 Note that `cols` is *not* a standard Julia function. It is only used to modify the 
-way that macros in DataFramesMeta escape arguments and has no behavior of its own. 
+way that macros in DataFramesMeta escape arguments and has no behavior of its own 
+outside of DataFramesMeta macros.
 
 
 ## LINQ-Style Queries and Transforms

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ end
 
 @with(df, df[:x .> 1, ^(:y)]) # The ^ means leave the :y alone
 
-colref = :x
-@with(df, :y + cols(colref)) # Equivalent to df[:y] + df[colref]
 ```
 
 `@with` is the fundamental macro used by the other metaprogramming
@@ -125,6 +123,40 @@ df2 = @byrow df begin
     end
 end
 ```
+
+## Working with column names programmatically with `cols`
+
+DataFramesMeta provides the special syntax, `cols`, for referring to 
+columns in a DataFrame via a `Symbol`, `String`, or column position. 
+
+```julia
+
+df = DataFrame(A = 1:3, B = [2, 1, 2])
+
+nameA = :A
+
+df2 = @transform(df, C = :B - cols(nameA))
+
+nameB = "B"
+df3 = @byrow df begin 
+    :A = cols(nameB)
+end
+
+```
+
+`cols` can also be used to create new columns in a DataFrame. 
+
+```julia
+df = DataFrame(A = 1:3, B = [2, 1, 2])
+
+newcol = "C"
+@select(df, cols(newcol) = :A + :B)
+
+@by(df, :B, cols("A complicated"  * " new name") = first(:A))
+
+```
+
+
 
 ## LINQ-Style Queries and Transforms
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ columns in a DataFrame via a `Symbol`, `String`, or column position.
 df = DataFrame(A = 1:3, B = [2, 1, 2])
 
 nameA = :A
-
 df2 = @transform(df, C = :B - cols(nameA))
 
 nameB = "B"
@@ -164,7 +163,6 @@ end
 
 Note that `cols` is *not* a standard Julia function. It is only used to modify the 
 way that macros in DataFramesMeta escape arguments and has no behavior of its own. 
-
 
 
 ## LINQ-Style Queries and Transforms

--- a/README.md
+++ b/README.md
@@ -154,7 +154,16 @@ newcol = "C"
 
 @by(df, :B, cols("A complicated"  * " new name") = first(:A))
 
+nameC = "C"
+df3 = @byrow df begin 
+    @newcol cols(nameC)::Vector{Int}
+    cols(nameC) = :A
+end
+
 ```
+
+Note that `cols` is *not* a standard Julia function. It is only used to modify the 
+way that macros in DataFramesMeta escape arguments and has no behavior of its own. 
 
 
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ end
 
 ## Working with column names programmatically with `cols`
 
-DataFramesMeta.jl provides the special syntax, `cols`, for referring to 
+DataFramesMeta.jl provides the special syntax `cols` for referring to 
 columns in a data frame via a `Symbol`, string, or column position as either
 a literal or a variable. 
 

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -156,7 +156,7 @@ function replace_dotted!(e, membernames)
 end
 
 getsinglecolumn(df, s::DataFrames.ColumnIndex) = df[!, s]
-getsinglecolumn(df, s) = throw(ArgumentError("Only indexing with Symbols and strings" *
+getsinglecolumn(df, s) = throw(ArgumentError("Only indexing with Symbols, strings and integers" *
     "is currently allowed with cols"))
 
 function with_helper(d, body)

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -112,11 +112,15 @@ function fun_to_vec(kw::Expr; nolhs = false)
                 ($(Expr(:tuple, values(membernames)...)) -> $body)
             end
          else
-            output = kw.args[1]
+            if onearg(kw.args[1], :cols)
+                output = kw.args[1].args[2]
+            else
+                output = QuoteNode(kw.args[1])
+            end
             t = quote
                 $(Expr(:vect, keys(membernames)...)) =>
                 ($(Expr(:tuple, values(membernames)...)) -> $body) =>
-                $(QuoteNode(output))
+                $(output)
             end
         end
         return t

--- a/src/byrow.jl
+++ b/src/byrow.jl
@@ -13,18 +13,11 @@ export @byrow
 function byrow_replace(e::Expr)
     # Traverse the syntax tree of e
     if onearg(e, :cols)
-        return Expr(:call, :(DataFramesMeta.getsingleindex), e, :row)
+        return Expr(:ref, Expr(:call, :cols, e.args[2]), :row)
     end
 
     Expr(e.head, (isempty(e.args) ? e.args : map(byrow_replace, e.args))...)
 end
-
-# If we see `cols([:x1, :x2])` this gets subsetted as `df[:, [:x1, :x2]]`
-# so here we make sure we aren't subsetting into a DataFrame.
-getsingleindex(df::AbstractDataFrame, idx) =
-    throw(ArgumentError("`cols` inside `@byrow` with multiple columns is reserved"))
-
-getsingleindex(x::AbstractVector, idx) = x[idx]
 
 byrow_replace(e::QuoteNode) = Expr(:ref, e, :row)
 

--- a/src/byrow.jl
+++ b/src/byrow.jl
@@ -13,6 +13,7 @@ export @byrow
 function byrow_replace(e::Expr)
     # Traverse the syntax tree of e
     if onearg(e, :cols)
+        # cols(:x) becomes cols(:x)[row]
         return Expr(:ref, Expr(:call, :cols, e.args[2]), :row)
     end
 

--- a/src/byrow.jl
+++ b/src/byrow.jl
@@ -19,8 +19,10 @@ function byrow_replace(e::Expr)
     Expr(e.head, (isempty(e.args) ? e.args : map(byrow_replace, e.args))...)
 end
 
+# If we see `cols([:x1, :x2])` this gets subsetted as `df[:, [:x1, :x2]]`
+# so here we make sure we aren't subsetting into a DataFrame.
 getsingleindex(df::AbstractDataFrame, idx) =
-    throw(ArgumentError("`cols` inside `@byrow` is reserved"))
+    throw(ArgumentError("`cols` inside `@byrow` with multiple columns is reserved"))
 
 getsingleindex(x::AbstractVector, idx) = x[idx]
 

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -31,6 +31,10 @@ const ≅ = isequal
     yr = "y"
     cr = "c"
 
+    n_str = "new_column"
+    n_sym = :new_column
+    n_space = "new column"
+
     @test @transform(df, n = :i).n == df.i
     @test @transform(df, n = :i .+ :g).n == df.i .+ df.g
     @test @transform(df, n = :t .* string.(:y)).n == df.t .* string.(df.y)
@@ -62,6 +66,12 @@ const ≅ = isequal
 
     @test @transform(df, :i) ≅ df
     @test @transform(df, :i, :g) ≅ df
+
+    @test @transform(df, cols("new_column") = :i).new_column == df.i
+    @test @transform(df, cols(n_str) = :i).new_column == df.i
+    @test @transform(df, cols(n_sym) = :i).new_column == df.i
+    @test @transform(df, cols(n_space) = :i)."new column" == df.i
+    @test @transform(df, cols("new" * "_" * "column") = :i).new_column == df.i
 
     @test @transform(df, n = 1).n == fill(1, nrow(df))
 end

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -115,8 +115,6 @@ s = [:i, :g]
     @test_throws LoadError @eval @transform(df, Between(:i, :t)).Between == df.i
     @test_throws LoadError @eval @transform(df, Not(:i)).Not == df.i
     @test_throws LoadError @eval @transform(df, Not([:i, :g]))
-    newvar = :n
-    @test_throws ArgumentError @eval @transform(df, cols(newvar) = :i)
     @test_throws MethodError @eval @transform(df, n = sum(Between(:i, :t)))
     @test_throws ArgumentError @eval @transform(df, n = sum(cols(s)))
 end
@@ -144,6 +142,10 @@ end
     tr = "t"
     yr = "y"
     cr = "c"
+
+    n_str = "new_column"
+    n_sym = :new_column
+    n_space = "new column"
 
     @test @select(df, :i) == df[!, [:i]]
     @test @select(df, :i, :g) == df[!, [:i, :g]]
@@ -178,6 +180,13 @@ end
     @test DataFramesMeta.select(df, :i) == df.i
 
     @test @select(df, n = 1).n == fill(1, nrow(df))
+
+    @test @select(df, cols("new_column") = :i).new_column == df.i
+    @test @select(df, cols(n_str) = :i).new_column == df.i
+    @test @select(df, cols(n_sym) = :i).new_column == df.i
+    @test @select(df, cols(n_space) = :i)."new column" == df.i
+    @test @select(df, cols("new" * "_" * "column") = :i).new_column == df.i
+
 end
 
 # Defined outside of `@testset` due to use of `@eval`
@@ -210,8 +219,6 @@ cr = "c"
     @test_throws LoadError @eval @select(df, Between(:i, :t)).Between == df.i
     @test_throws LoadError @eval  @select(df, Not(:i)).Not == df.i
     @test_throws LoadError @eval @select(df, Not([:i, :g]))
-    newvar = :n
-    @test_throws ArgumentError @eval @select(df, cols(newvar) = :i)
     @test_throws MethodError @eval @select(df, n = sum(Between(:i, :t)))
     @test_throws ArgumentError @eval @select(df, n = sum(cols(s)))
 end

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -326,6 +326,24 @@ end
         :B = cols(n)
     end
     @test df2 == DataFrame(A = 1:3, B = 1:3)
+
+    n = :A
+    df2 = @byrow df begin
+        cols(n) = :B
+    end
+    @test df2 == DataFrame(A = [2, 1, 2], B = [2, 1, 2])
+
+    n = "A"
+    df2 = @byrow df begin
+        cols(n) = :B
+    end
+    @test df2 == DataFrame(A = [2, 1, 2], B = [2, 1, 2])
+
+    n = 1
+    df2 = @byrow df begin
+        cols(n) = :B
+    end
+    @test df2 == DataFrame(A = [2, 1, 2], B = [2, 1, 2])
 end
 
 df = DataFrame(A = 1:3, B = [2, 1, 2])

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -344,6 +344,21 @@ end
         cols(n) = :B
     end
     @test df2 == DataFrame(A = [2, 1, 2], B = [2, 1, 2])
+
+
+    n = :C
+    df2 = @byrow df begin
+        @newcol cols(n)::Vector{Int}
+        cols(n) = :B
+    end
+    @test df2 == DataFrame(A = [1, 2, 3], B = [2, 1, 2], C = [2, 1, 2])
+
+    n = "C"
+    df2 = @byrow df begin
+        @newcol cols(n)::Vector{Int}
+        cols(n) = :B
+    end
+    @test df2 == DataFrame(A = [1, 2, 3], B = [2, 1, 2], C = [2, 1, 2])
 end
 
 df = DataFrame(A = 1:3, B = [2, 1, 2])

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -163,7 +163,6 @@ end
     @test @by(df, :g, n = first(Symbol.(:y, ^(:body)))).n == [:vbody, :ybody]
     @test @by(df, :g, body = :i).body == df.i
     @test @by(df, :g, transform = :i).transform == df.i
-    # TODO: Make `t = :n1; (cols(t) = ...,)` work
     @test @by(df, :g, (n1 = [first(:i)], n2 = [first(:y)])).n1 == [1, 4]
 
     @test @by(df, :g, n = mean(cols(iq))).n == [2.0, 4.5]

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -45,7 +45,9 @@ g = groupby(d, :x, sort=true)
 
     gd = groupby(df, :g)
 
-    newvar = :n
+    n_str = "new_column"
+    n_sym = :new_column
+    n_space = "new column"
 
     @test @based_on(gd, n = mean(:i)).n == [2.0, 4.5]
     @test @based_on(gd, n = mean(:i) + mean(:g)).n == [3.0, 6.5]
@@ -78,6 +80,13 @@ g = groupby(d, :x, sort=true)
     @test @based_on(gd, :i, :g) ≅ select(df, :g, :i)
 
     @test @based_on(gd, :i, n = 1).n == fill(1, nrow(df))
+
+    @test @based_on(gd, cols("new_column") = 2).new_column == [2, 2]
+    @test @based_on(gd, cols(n_str) = 2).new_column == [2, 2]
+    @test @based_on(gd, cols(n_sym) = 2).new_column == [2, 2]
+    @test @based_on(gd, cols(n_space) = 2)."new column" == [2, 2]
+    @test @based_on(gd, cols("new" * "_" * "column") = 2)."new_column" == [2, 2]
+
 end
 
 # Defined outside of `@testset` due to use of `@eval`
@@ -114,7 +123,6 @@ newvar = :n
     @test @based_on(gd, All()).function isa Vector{<:All}
     @test @based_on(gd, Not(:i)).i_function isa Vector{<:InvertedIndex}
     @test @based_on(gd, Not([:i, :g])).g == [1, 2]
-    @test_throws ArgumentError @eval @based_on(gd, cols(newvar) = mean(:i))
     @test_throws MethodError @eval @based_on(gd, n = sum(Between(:i, :t)))
     @test_throws LoadError @eval @based_on(gd; n = mean(:i))
 end
@@ -144,7 +152,10 @@ end
 
     gd = groupby(df, :g)
 
-    newvar = :n
+    n_str = "new_column"
+    n_sym = :new_column
+    n_space = "new column"
+
     @test @by(df, :g, n = mean(:i)).n == [2.0, 4.5]
     @test @by(df, :g, n = mean(:i) + mean(:g)).n == [3.0, 6.5]
     @test @by(df, :g, n = first(:t .* string.(:y))).n == ["av", "cy"]
@@ -152,6 +163,7 @@ end
     @test @by(df, :g, n = first(Symbol.(:y, ^(:body)))).n == [:vbody, :ybody]
     @test @by(df, :g, body = :i).body == df.i
     @test @by(df, :g, transform = :i).transform == df.i
+    # TODO: Make `t = :n1; (cols(t) = ...,)` work
     @test @by(df, :g, (n1 = [first(:i)], n2 = [first(:y)])).n1 == [1, 4]
 
     @test @by(df, :g, n = mean(cols(iq))).n == [2.0, 4.5]
@@ -176,6 +188,12 @@ end
     @test @by(df, :g, :i, :g) ≅ select(df, :g, :i)
 
     @test @by(df, :g, :i, n = 1).n == fill(1, nrow(df))
+
+    @test @by(df, :g, cols("new_column") = 2).new_column == [2, 2]
+    @test @by(df, :g, cols(n_str) = 2).new_column == [2, 2]
+    @test @by(df, :g, cols(n_sym) = 2).new_column == [2, 2]
+    @test @by(df, :g, cols(n_space) = 2)."new column" == [2, 2]
+    @test @by(df, :g, cols("new" * "_" * "column") = 2)."new_column" == [2, 2]
 end
 
 # Defined outside of `@testset` due to use of `@eval`
@@ -212,7 +230,6 @@ newvar = :n
     @test @by(df, :g, All()).function isa Vector{<:All}
     @test @by(df, :g, Not(:i)).i_function isa Vector{<:InvertedIndex}
     @test @by(df, :g, Not([:i, :g])).g == [1, 2]
-    @test_throws ArgumentError @eval @by(df, :g, cols(newvar) = mean(:i))
     @test_throws MethodError @eval @by(df, :g, n = sum(Between(:i, :t)))
     @test_throws MethodError @eval @by(df, :g; n = mean(:i))
 end

--- a/test/linqmacro.jl
+++ b/test/linqmacro.jl
@@ -68,9 +68,11 @@ xlinq3 = @linq df  |>
     xlinq3 = @linq df  |>
         where(cols(a_sym) .> 2, :b .!= "c")  |>
         transform(cols(y_str) = 10 * cols(x_sym))  |>
-        DataFrames.groupby(cols(b_str)) |>
-        orderby(-mean(cols(x_str)))  |>
-        based_on(cols("meanY") = mean(:x), meanY = mean(:y))
+        DataFrames.groupby(b_str) |>
+        orderby(-mean(cols(x_sym)))  |>
+        based_on(cols("meanX") = mean(:x), meanY = mean(:y))
+
+    @test isequal(xlinq3, DataFrame(b = "d", meanX = 40.0, meanY = 400.0))
 end
 
 end # module

--- a/test/linqmacro.jl
+++ b/test/linqmacro.jl
@@ -53,4 +53,24 @@ xlinq3 = @linq df  |>
 
 @test (@linq df |> with(:a)) == df.a
 
+@testset "@linq with `cols`" begin
+    df = DataFrame(
+            a = [1, 2, 3, 4],
+            b = ["a", "b", "c", "d"],
+            x = [10, 20, 30, 40],
+            y = [40, 50, 60, 70]
+        )
+
+    a_sym = :a
+    b_str = "b"
+    x_sym = :x
+    y_str = "y"
+    xlinq3 = @linq df  |>
+        where(cols(a_sym) .> 2, :b .!= "c")  |>
+        transform(cols(y_str) = 10 * cols(x_sym))  |>
+        DataFrames.groupby(cols(b_str)) |>
+        orderby(-mean(cols(x_str)))  |>
+        based_on(cols("meanY") = mean(:x), meanY = mean(:y))
 end
+
+end # module


### PR DESCRIPTION
This will enable 

```
newname = :y 
df = DataFrame(x1 = [1], x2 = [2])
@transform(df, cols(newname) = :x1 + :x2)
```

This is a relatively uncontroversial and easy to implement feature! Tests will be added soon. 