### PR TITLE
fix nested transforms

### DIFF
--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -693,15 +693,11 @@ end
 ##
 ##############################################################################
 
-_select(x::AbstractDataFrame, args...) = DataFrames.select(x, args...)
-
-_select(x::GroupedDataFrame, args...) = throw(ArgumentError("@select with a grouped data frame is reserved"))
-
 function select_helper(x, args...)
     t = (fun_to_vec(arg) for arg in args)
 
     quote
-        $_select($x, $(t...))
+        $DataFrames.select($x, $(t...))
     end
 end
 

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -456,17 +456,17 @@ end
 ##
 ##############################################################################
 
+_transform(x::AbstractDataFrame, args...) = DataFrames.transform(x, args...)
+
+_transform(x::GroupedDataFrame, args...) = DataFrames.transform(x, args...)[x.idx, :]
+
 
 function transform_helper(x, args...)
 
     t = (fun_to_vec(arg) for arg in args)
 
     quote
-        out = $DataFrames.transform($x, $(t...))
-        if $x isa GroupedDataFrame
-            out = out[$x.idx, :]
-        end
-        out
+        $_transform($x, $(t...))
     end
 end
 
@@ -693,11 +693,15 @@ end
 ##
 ##############################################################################
 
+_select(x::AbstractDataFrame, args...) = DataFrames.select(x, args...)
+
+_select(x::GroupedDataFrame, args...) = throw(ArgumentError("@select with a grouped data frame is reserved"))
+
 function select_helper(x, args...)
     t = (fun_to_vec(arg) for arg in args)
 
     quote
-        $DataFrames.select($x, $(t...))
+        $_select($x, $(t...))
     end
 end
 

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -324,4 +324,17 @@ df = DataFrame(A = 1:3, B = [2, 1, 2])
     @test_throws ArgumentError @eval @byrow df begin cols(n) end
 end
 
+@testset "nested macros" begin
+    df = DataFrame(a = [1, 1, 2, 2, 3, 3], b = [1, 2, 3, 4, 5, 6])
+
+    @test @transform(@transform(df, c1 = :a .* 2), c2 = :b .*2).c2 == df.b .*2
+    @test @select(@select(df, c1 = :a .* 2, :b), c2 = :b .*2).c2 == df.b .*2
+
+    @test @transform(@by(df, :a, c1 = first(:b)), c2 = 1).c2 == [1, 1, 1]
+    @test @by(@transform(df, c1 = 1), :a, c2 = first(:b)).c2 == [1, 3, 5]
+
+    @test @transform(@based_on(groupby(df, :a), c1 = first(:b)), c2 = 1).c2 == [1, 1, 1]
+    @test @based_on(groupby(@transform(df, c1 = 1), :a), c2 = first(:b)).c2 == [1, 3, 5]
+end
+
 end # module


### PR DESCRIPTION
Fixes #176 

There were 3 problems with master: 

```
    quote
        out = $DataFrames.transform($x, $(t...))
        if $x isa GroupedDataFrame
            out = out[$x.idx, :]
        end
    out
```

1. This introduces the variable `out` in global scope. 
2. We write `$x` multiple times, meaning we actually evaluate the first `@transform` in `@transform(@transform(df, ...), ...)` *three* times in a single call.
3. The code is much to complicated to reason about when you try to imagine it inside a function call, i.e. on master the generated code is something like 

```
out = transform(out = transform(df,...); if df isa GroupedDataFrame ...`)
if transform(df ...) isa GroupedDataFrame
```

I'm still not 100% sure it was skipping the second transform call but it has to do with the branchine and the intermediate variable assignment. 

Solution: wrap the behavior I want in a little function. That way `$x` is only evaluated once. 

Note that this is a stop-gap. Eventually we will not have to need to use this. But I want breaking changes to be deliberate and I need to focus on writing correct tests, which I can't do if I break everything at once. 
