### PR TITLE
Fix mixing `Symbol`s and `String`s in `cols`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,3 +4,5 @@
   order of rows returned after `DataFrames.transform(gd::GroupedDataFrame, args...)`. 
 * `@select` now supports `GroupedDataFrame` with the same behavior as 
   `DataFrames.select(df::GroupedDataFrame, args...)` ([#180])
+* Restrictions are imposed on the types of column references allowed when using `cols`. 
+  Mixing integer column references with other types now errors. ([#183])

--- a/README.md
+++ b/README.md
@@ -136,8 +136,11 @@ df = DataFrame(A = 1:3, B = [2, 1, 2])
 nameA = :A
 df2 = @transform(df, C = :B - cols(nameA))
 
+nameA_string = "A"
+df2 = @transform(df, C = :B - cols(nameA_string))
+
 nameB = "B"
-df3 = @byrow df begin 
+df4 = @byrow df begin 
     :A = cols(nameB)
 end
 ```

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -145,7 +145,7 @@ function repair_source(x)
     if isempty(x) || isconcretetype(eltype(x))
         return x
     elseif all(t -> t isa Union{AbstractString, Symbol}, x)
-        return [xi isa AbstractString ? Symbol(xi) : xi for xi in x]
+        return Symbol.(x)
     else
         throw(ArgumentError("Column references must be either all the same " *
                             "type or a a combination of `Symbol`s and strings"))

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -116,7 +116,7 @@ function fun_to_vec(kw::Expr; nolhs = false)
         if nolhs
             # [:x] => _f
             t = quote
-                DataFramesMeta.repair_source($(source)) =>
+                DataFramesMeta.make_source_concrete($(source)) =>
                 ($(Expr(:tuple, values(membernames)...)) -> $body)
             end
          else
@@ -128,7 +128,7 @@ function fun_to_vec(kw::Expr; nolhs = false)
                 output = kw.args[1].args[2]
             end
             t = quote
-                DataFramesMeta.repair_source($(source)) =>
+                DataFramesMeta.make_source_concrete($(source)) =>
                 ($(Expr(:tuple, values(membernames)...)) -> $body) =>
                 $(output)
             end
@@ -141,7 +141,7 @@ end
 
 fun_to_vec(kw::QuoteNode) = kw
 
-function repair_source(x::AbstractVector)
+function make_source_concrete(x::AbstractVector)
     if isempty(x) || isconcretetype(eltype(x))
         return x
     elseif all(t -> t isa Union{AbstractString, Symbol}, x)
@@ -182,7 +182,7 @@ function with_helper(d, body)
         function $funname($(values(membernames)...))
             $body
         end
-        $funname((DataFramesMeta.getsinglecolumn($_d, s) for s in  DataFramesMeta.repair_source($source))...)
+        $funname((DataFramesMeta.getsinglecolumn($_d, s) for s in  DataFramesMeta.make_source_concrete($source))...)
     end
 end
 

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -141,7 +141,7 @@ end
 
 fun_to_vec(kw::QuoteNode) = kw
 
-function repair_source(x)
+function repair_source(x::AbstractVector)
     if isempty(x) || isconcretetype(eltype(x))
         return x
     elseif all(t -> t isa Union{AbstractString, Symbol}, x)

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -111,10 +111,12 @@ function fun_to_vec(kw::Expr; nolhs = false)
             body = replace_syms!(kw.args[2], membernames)
         end
 
+        source = Expr(:vect, keys(membernames)...)
+
         if nolhs
             # [:x] => _f
             t = quote
-                $(Expr(:vect, keys(membernames)...)) =>
+                Symbol.($(source)) =>
                 ($(Expr(:tuple, values(membernames)...)) -> $body)
             end
          else
@@ -126,7 +128,7 @@ function fun_to_vec(kw::Expr; nolhs = false)
                 output = kw.args[1].args[2]
             end
             t = quote
-                $(Expr(:vect, keys(membernames)...)) =>
+                 Symbol.($(source)) =>
                 ($(Expr(:tuple, values(membernames)...)) -> $body) =>
                 $(output)
             end

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -147,7 +147,7 @@ function repair_source(x)
     elseif all(t -> t isa Union{AbstractString, Symbol}, x)
         return [xi isa AbstractString ? Symbol(xi) : xi for xi in x]
     else
-        throw(ArgumentError("Inputs to anonymous function must be either all the same " *
+        throw(ArgumentError("Column references must be either all the same " *
                             "type or a a combination of `Symbol`s and strings"))
     end
 end
@@ -182,7 +182,7 @@ function with_helper(d, body)
         function $funname($(values(membernames)...))
             $body
         end
-        $funname([DataFramesMeta.getsinglecolumn($_d, s) for s in  DataFramesMeta.repair_source($source)]...)
+        $funname((DataFramesMeta.getsinglecolumn($_d, s) for s in  DataFramesMeta.repair_source($source))...)
     end
 end
 

--- a/test/byrow.jl
+++ b/test/byrow.jl
@@ -81,12 +81,6 @@ end
     end
     @test df2 == DataFrame(A = 1:3, B = 1:3)
 
-    n = 1
-    df2 = @byrow df begin
-        :B = cols(n)
-    end
-    @test df2 == DataFrame(A = 1:3, B = 1:3)
-
     df2 = @byrow df begin
         :A = cols(:A) + cols("B")
     end
@@ -103,13 +97,6 @@ end
         cols(n) = :B
     end
     @test df2 == DataFrame(A = [2, 1, 2], B = [2, 1, 2])
-
-    n = 1
-    df2 = @byrow df begin
-        cols(n) = :B
-    end
-    @test df2 == DataFrame(A = [2, 1, 2], B = [2, 1, 2])
-
 
     n = :C
     df2 = @byrow df begin
@@ -137,6 +124,8 @@ df = DataFrame(A = 1:3, B = [2, 1, 2])
 
     @eval Testbyrow n = [1, 2]
     @test_throws ArgumentError @eval @byrow df begin cols(n) end
+
+    @test_throws ArgumentError @byrow df cols(1) + cols(:A)
 end
 
 end # module

--- a/test/byrow.jl
+++ b/test/byrow.jl
@@ -87,6 +87,11 @@ end
     end
     @test df2 == DataFrame(A = 1:3, B = 1:3)
 
+    df2 = @byrow df begin
+        :A = cols(:A) + cols("B")
+    end
+    @test df2.A == df.A + df.B
+
     n = :A
     df2 = @byrow df begin
         cols(n) = :B

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -254,6 +254,9 @@ end
     @test  @with(df, cols(idx) .+ :B)  ==  df.A .+ df.B
     idx2 = :B
     @test  @with(df, cols(idx) .+ cols(idx2))  ==  df.A .+ df.B
+    @test  @with(df, cols(:A) .+ cols("B"))  ==  df.A .+ df.B
+
+    @test_throws ArgumentError @with(df, :A + cols(2))
 
     @test  x == sum(df.A .* df.B)
     @test  @with(df, df[:A .> 1, ^([:B, :A])]) == df[df.A .> 1, [:B, :A]]

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -59,6 +59,7 @@ const ≅ = isequal
     @test @transform(df, body = cols(ir)).body == df.i
     @test @transform(df, transform = cols(ir)).transform == df.i
     @test @transform(df, n = cols("g") + cols(:i)).n == df.g + df.i
+    @test @transform(df, n = cols(1) + cols(2)).n == df.g + df.i
 
     @test @transform(df, n = :i).g !== df.g
 
@@ -118,6 +119,7 @@ s = [:i, :g]
     @test_throws LoadError @eval @transform(df, Not([:i, :g]))
     @test_throws MethodError @eval @transform(df, n = sum(Between(:i, :t)))
     @test_throws ArgumentError @eval @transform(df, n = sum(cols(s)))
+    @test_throws ArgumentError @eval @transform(df, y = :i + cols(1))
 end
 
 @testset "@select" begin
@@ -178,6 +180,8 @@ end
     @test @select(df, body = cols(ir)).body == df.i
     @test @select(df, transform = cols(ir)).transform == df.i
     @test @select(df, n = cols("g") + cols(:i)).n == df.g + df.i
+    @test @select(df, n = cols(1) + cols(2)).n == df.g + df.i
+
 
     @test DataFramesMeta.select(df, :i) == df.i
 
@@ -222,6 +226,7 @@ cr = "c"
     @test_throws LoadError @eval @select(df, Not([:i, :g]))
     @test_throws MethodError @eval @select(df, n = sum(Between(:i, :t)))
     @test_throws ArgumentError @eval @select(df, n = sum(cols(s)))
+    @test_throws ArgumentError @eval @select(df, y = :i + cols(1))
 end
 
 @testset "Keyword arguments failure" begin

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -58,6 +58,7 @@ const ≅ = isequal
     @test @transform(df, n = Symbol.(cols(yr), ^(:body))).n == Symbol.(df.y, :body)
     @test @transform(df, body = cols(ir)).body == df.i
     @test @transform(df, transform = cols(ir)).transform == df.i
+    @test @transform(df, n = cols("g") + cols(:i)).n == df.g + df.i
 
     @test @transform(df, n = :i).g !== df.g
 
@@ -176,6 +177,7 @@ end
     @test @select(df, n = Symbol.(cols(yr), ^(:body))).n == Symbol.(df.y, :body)
     @test @select(df, body = cols(ir)).body == df.i
     @test @select(df, transform = cols(ir)).transform == df.i
+    @test @select(df, n = cols("g") + cols(:i)).n == df.g + df.i
 
     @test DataFramesMeta.select(df, :i) == df.i
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -76,6 +76,8 @@ g = groupby(d, :x, sort=true)
     @test @based_on(gd, transform = cols(ir)).transform == df.i
     @test @based_on(gd, (n1 = [first(cols(ir))], n2 = [first(cols(yr))])).n1 == [1, 4]
     @test @based_on(gd, n = mean(cols("i")) + 0 * first(cols(:g))).n == [2.0, 4.5]
+    @test @based_on(gd, n = mean(cols(2)) + first(cols(1))).n == [3.0, 6.5]
+
 
     @test @based_on(gd, :i) == select(df, :g, :i)
     @test @based_on(gd, :i, :g) ≅ select(df, :g, :i)
@@ -125,6 +127,7 @@ newvar = :n
     @test @based_on(gd, Not([:i, :g])).g == [1, 2]
     @test_throws MethodError @eval @based_on(gd, n = sum(Between(:i, :t)))
     @test_throws LoadError @eval @based_on(gd; n = mean(:i))
+    @test_throws ArgumentError @eval @based_on(gd, n = mean(:i) + mean(cols(1)))
 end
 
 @testset "@by" begin
@@ -183,6 +186,8 @@ end
     @test @by(df, "g", transform = cols(ir)).transform == df.i
     @test @by(df, "g", (n1 = [first(cols(ir))], n2 = [first(cols(yr))])).n1 == [1, 4]
     @test @by(df, "g", n = mean(cols("i")) + 0 * first(cols(:g))).n == [2.0, 4.5]
+    @test @by(df, "g", n = mean(cols(2)) + first(cols(1))).n == [3.0, 6.5]
+
 
     @test @by(df, :g, :i) == select(df, :g, :i)
     @test @by(df, :g, :i, :g) ≅ select(df, :g, :i)
@@ -232,6 +237,7 @@ newvar = :n
     @test @by(df, :g, Not([:i, :g])).g == [1, 2]
     @test_throws MethodError @eval @by(df, :g, n = sum(Between(:i, :t)))
     @test_throws MethodError @eval @by(df, :g; n = mean(:i))
+    @test_throws ArgumentError @eval @by(df, :g, n = mean(:i) + mean(cols(1)))
 end
 
 @testset "@transform with grouped data frame" begin

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -75,6 +75,7 @@ g = groupby(d, :x, sort=true)
     @test @based_on(gd, body = cols(ir)).body == df.i
     @test @based_on(gd, transform = cols(ir)).transform == df.i
     @test @based_on(gd, (n1 = [first(cols(ir))], n2 = [first(cols(yr))])).n1 == [1, 4]
+    @test @based_on(gd, n = mean(cols("i")) + 0 * first(cols(:g))).n == [2.0, 4.5]
 
     @test @based_on(gd, :i) == select(df, :g, :i)
     @test @based_on(gd, :i, :g) ≅ select(df, :g, :i)
@@ -181,6 +182,7 @@ end
     @test @by(df, "g", body = cols(ir)).body == df.i
     @test @by(df, "g", transform = cols(ir)).transform == df.i
     @test @by(df, "g", (n1 = [first(cols(ir))], n2 = [first(cols(yr))])).n1 == [1, 4]
+    @test @by(df, "g", n = mean(cols("i")) + 0 * first(cols(:g))).n == [2.0, 4.5]
 
     @test @by(df, :g, :i) == select(df, :g, :i)
     @test @by(df, :g, :i, :g) ≅ select(df, :g, :i)


### PR DESCRIPTION
Fixes #181 

This was an easy fix with easy tests to add. 

In the future this might get re-factored to allow for multiple column inputs in `cols`, but not today. 