### PR TITLE
Re-do the `@orderby` backend

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,6 @@
   order of rows returned after `DataFrames.transform(gd::GroupedDataFrame, args...)`. 
 * `@select` now supports `GroupedDataFrame` with the same behavior as 
   `DataFrames.select(df::GroupedDataFrame, args...)` ([#180])
-* `@orderby(gd::GroupedDataFrame, args...)` now returns a `DataFrame` instead 
-  of a `GroupedDataFrame`. Operations are performed by group similar to `@transform` 
-  and `@select`. 
+* `@orderby(gd::GroupedDataFrame, args...)` is now reserved and will error.
 * Restrictions are imposed on the types of column references allowed when using `cols`. 
   Mixing integer column references with other types now errors. ([#183])

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,3 +4,6 @@
   order of rows returned after `DataFrames.transform(gd::GroupedDataFrame, args...)`. 
 * `@select` now supports `GroupedDataFrame` with the same behavior as 
   `DataFrames.select(df::GroupedDataFrame, args...)` ([#180])
+* `@orderby(gd::GroupedDataFrame, args...)` now returns a `DataFrame` instead 
+  of a `GroupedDataFrame`. Operations are performed by group similar to `@transform` 
+  and `@select`. 

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.5.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,10 @@ version = "0.5.1"
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 DataFrames = "0.21"
 Reexport = "0.2"
-Tables = "1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "0.5.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ The following operations are now included:
   GroupedDataFrame.
 
 - `orderby(g, d -> mean(d[:a]))` and `@orderby(g, mean(:a))` -- Sort
-  groups based on the given criteria. Returns a GroupedDataFrame.
+  observations by a given criteria. 
 
 - `DataFrame(g)` -- Convert groups back to a DataFrame with the same
   group orderings.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ end
 
 ## `@orderby`
 
-Sort rows by values in one of several columns or a transformation of columns.
+Sort rows in a `DataFrame` by values in one of several columns or a 
+transformation of columns.
 
 ```julia
 d = DataFrame(x = [3, 3, 3, 2, 1, 1, 1, 2, 1, 1], n = 1:10);

--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ df2 = @byrow df begin
 end
 ```
 
+## `@orderby`
+
+Re-order rows of a data frame 
+
+```julia
+d = DataFrame(x = [3, 3, 3, 2, 1, 1, 1, 2, 1, 1], n = 1:10);
+@orderby(d, -1 .* :n)
+g = groupby(d, :x);
+@orderby(g, :x, :n .- mean(:n))
+```
+
 ## Working with column names programmatically with `cols`
 
 DataFramesMeta.jl provides the special syntax `cols` for referring to 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ Sort rows by values in one of several columns or a transformation of columns.
 ```julia
 d = DataFrame(x = [3, 3, 3, 2, 1, 1, 1, 2, 1, 1], n = 1:10);
 @orderby(d, -1 .* :n)
-g = groupby(d, :x);
-@orderby(g, :x, :n .- mean(:n))
+@orderby(d, :x, :n .- mean(:x))
 ```
 
 ## Working with column names programmatically with `cols`

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -1,6 +1,6 @@
 module DataFramesMeta
 
-using Tables, Reexport
+using Reexport
 
 @reexport using DataFrames
 

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -400,7 +400,7 @@ function orderby(x::AbstractDataFrame, @nospecialize(args...))
 end
 
 function orderby(x::GroupedDataFrame, @nospecialize(args...))
-    t = DataFrames.select(x, args...; copycols = false)
+    t = DataFrames.select(x, args...; copycols = false, keepkeys = false)
     parent(x)[sortperm(t), :]
 end
 

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -410,6 +410,10 @@ function orderby(x::AbstractDataFrame, @nospecialize(args...))
 end
 
 function orderby(x::GroupedDataFrame, @nospecialize(args...))
+
+    @warn "orderby behavior now returns a `DataFrame` instead of a `GroupedDataFrame`. " *
+          "Group the returned data frame to restore old behavior" maxlog = 5
+
     t = DataFrames.select(x, args...; copycols = false, keepkeys = false)
     parent(x)[sortperm(t), :]
 end

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -410,33 +410,22 @@ function orderby(x::AbstractDataFrame, @nospecialize(args...))
 end
 
 function orderby(x::GroupedDataFrame, @nospecialize(args...))
-    @warn "orderby behavior now returns a `DataFrame` instead of a `GroupedDataFrame`. " *
-          "Group the returned data frame to restore old behavior" maxlog = 2
-
-    t = DataFrames.select(x, args...; copycols = false, keepkeys = false)
-    @assert nrow(parent(x)) == nrow(t)
-    parent(x)[sortperm(t), :]
+    throw(ArgumentError("@orderby with a GroupedDataFrame is reserved"))
 end
 
 """
     @orderby(d, i...)
 
 Sort rows by values in one of several columns or a transformation of columns.
-Always returns a fresh `DataFrame` regardless of whether the input is a `DataFrame` or a
-`GroupedDataFrame`.
+Always returns a fresh `DataFrame`. Does not accept a `GroupedDataFrame`.
 
 When given a `DataFrame`, `@orderby` applies the transformation
 given by its arguments (but does not create new columns) and sorts
 the given `DataFrame` on the result, returning a new `DataFrame`.
 
-When inputting a `GroupedDataFrame`, to return a `DataFrame` sorted
-first by group and then sorted by the tranformation, use the
-grouping columns of the the `GroupedDataFrame` as the first arguments
-of the`@orderby` call. See the final example below for a demonstration.
-
 ### Arguments
 
-* `d` : an AbstractDataFrame or GroupedDataFrame
+* `d` : an AbstractDataFrame
 * `i...` : expression for sorting
 
 ### Examples
@@ -461,54 +450,23 @@ julia> @orderby(d, -1 .* :n)
 │ 8   │ 3     │ 3     │
 │ 9   │ 3     │ 2     │
 │ 10  │ 3     │ 1     │
-```
 
-The second example below shows the logic of `@orderby` with a
-`GroupedDataFrame`. Note that the column `:t` is arranged from
-lowest to highest after the `@orderby` command. This shows that
-`@orderby` is equivelent to a transformation by group followed
-by ordering on the subsequent transformation.
-
-```jldoctest
-julia> g = groupby(d, :x);
-
-julia> @linq g |>
-       transform(t = :n .- mean(:n)) |>
-       orderby(:n .- mean(:n))
-
-10×3 DataFrame
-│ Row │ x     │ n     │ t       │
-│     │ Int64 │ Int64 │ Float64 │
-├─────┼───────┼───────┼─────────┤
-│ 1   │ 3     │ 1     │ -1.0    │
-│ 2   │ 3     │ 2     │ 0.0     │
-│ 3   │ 3     │ 3     │ 1.0     │
-│ 4   │ 2     │ 4     │ -2.0    │
-│ 5   │ 1     │ 5     │ -2.4    │
-│ 6   │ 1     │ 6     │ -1.4    │
-│ 7   │ 1     │ 7     │ -0.4    │
-│ 8   │ 2     │ 8     │ 2.0     │
-│ 9   │ 1     │ 9     │ 1.6     │
-│ 10  │ 1     │ 10    │ 2.6     │
-
-
-julia> @orderby(d, :x, -1 .* :n)
+julia> @orderby(d, :x, :n .- mean(:n))
 10×2 DataFrame
 │ Row │ x     │ n     │
 │     │ Int64 │ Int64 │
 ├─────┼───────┼───────┤
-│ 1   │ 1     │ 10    │
-│ 2   │ 1     │ 9     │
+│ 1   │ 1     │ 5     │
+│ 2   │ 1     │ 6     │
 │ 3   │ 1     │ 7     │
-│ 4   │ 1     │ 6     │
-│ 5   │ 1     │ 5     │
-│ 6   │ 2     │ 8     │
-│ 7   │ 2     │ 4     │
-│ 8   │ 3     │ 3     │
+│ 4   │ 1     │ 9     │
+│ 5   │ 1     │ 10    │
+│ 6   │ 2     │ 4     │
+│ 7   │ 2     │ 8     │
+│ 8   │ 3     │ 1     │
 │ 9   │ 3     │ 2     │
-│ 10  │ 3     │ 1     │
+│ 10  │ 3     │ 3     │
 ```
-
 """
 macro orderby(d, args...)
     esc(orderby_helper(d, args...))

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -412,7 +412,7 @@ end
 function orderby(x::GroupedDataFrame, @nospecialize(args...))
 
     @warn "orderby behavior now returns a `DataFrame` instead of a `GroupedDataFrame`. " *
-          "Group the returned data frame to restore old behavior" maxlog = 5
+          "Group the returned data frame to restore old behavior" maxlog = 2
 
     t = DataFrames.select(x, args...; copycols = false, keepkeys = false)
     parent(x)[sortperm(t), :]

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -143,6 +143,7 @@ function fun_to_vec(kw::Expr; nolhs = false)
     end
 end
 
+fun_to_vec(kw::QuoteNode; nolhs = false) = kw
 
 function make_source_concrete(x::AbstractVector)
     if isempty(x) || isconcretetype(eltype(x))

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -430,15 +430,6 @@ When given a `DataFrame`, `@orderby` applies the transformation
 given by its arguments (but does not create new columns) and sorts
 the given `DataFrame` on the result, returning a new `DataFrame`.
 
-When given a `GroupedDataFrame`, `@orderby` applies the transformation
-given by its arguments *by group*. Then it returns the `parent` of the
-input `GroupedDataFrame` which has been sorted by the transformations.
-The second example below shows the logic of `@orderby` with a
-`GroupedDataFrame`. Note that the column `:t` is arranged from
-lowest to highest after the `@orderby` command. This shows that
-`@orderby` is equivelent to a transformation by group followed
-by ordering on the subsequent transformation.
-
 When inputting a `GroupedDataFrame`, to return a `DataFrame` sorted
 first by group and then sorted by the tranformation, use the
 grouping columns of the the `GroupedDataFrame` as the first arguments
@@ -471,7 +462,18 @@ julia> @orderby(d, -1 .* :n)
 │ 8   │ 3     │ 3     │
 │ 9   │ 3     │ 2     │
 │ 10  │ 3     │ 1     │
+```
 
+When given a `GroupedDataFrame`, `@orderby` applies the transformation
+given by its arguments *by group*. Then it returns the `parent` of the
+input `GroupedDataFrame` which has been sorted by the transformations.
+The second example below shows the logic of `@orderby` with a
+`GroupedDataFrame`. Note that the column `:t` is arranged from
+lowest to highest after the `@orderby` command. This shows that
+`@orderby` is equivelent to a transformation by group followed
+by ordering on the subsequent transformation.
+
+```jldoctest
 julia> g = groupby(d, :x);
 
 julia> @linq g |>

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -434,7 +434,10 @@ When given a `GroupedDataFrame`, `@orderby` applies the transformation
 given by its arguments *by group*. Then it returns the `parent` of the
 input `GroupedDataFrame` which has been sorted by the transformations.
 The second example below shows the logic of `@orderby` with a
-`GroupedDataFrame`.
+`GroupedDataFrame`. Note that the column `:t` is arranged from
+lowest to highest after the `@orderby` command. This shows that
+`@orderby` is equivelent to a transformation by group followed
+by ordering on the subsequent transformation.
 
 When inputting a `GroupedDataFrame`, to return a `DataFrame` sorted
 first by group and then sorted by the tranformation, use the
@@ -490,21 +493,22 @@ julia> @linq g |>
 │ 9   │ 1     │ 9     │ 1.6     │
 │ 10  │ 1     │ 10    │ 2.6     │
 
+
 julia> @orderby(d, :x, -1 .* :n)
 10×2 DataFrame
-│ Row │ n     │ x     │
+│ Row │ x     │ n     │
 │     │ Int64 │ Int64 │
 ├─────┼───────┼───────┤
-│ 1   │ 10    │ 1     │
-│ 2   │ 9     │ 1     │
-│ 3   │ 7     │ 1     │
-│ 4   │ 6     │ 1     │
-│ 5   │ 5     │ 1     │
-│ 6   │ 8     │ 2     │
-│ 7   │ 4     │ 2     │
+│ 1   │ 1     │ 10    │
+│ 2   │ 1     │ 9     │
+│ 3   │ 1     │ 7     │
+│ 4   │ 1     │ 6     │
+│ 5   │ 1     │ 5     │
+│ 6   │ 2     │ 8     │
+│ 7   │ 2     │ 4     │
 │ 8   │ 3     │ 3     │
-│ 9   │ 2     │ 3     │
-│ 10  │ 1     │ 3     │
+│ 9   │ 3     │ 2     │
+│ 10  │ 3     │ 1     │
 ```
 
 """

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -4,8 +4,6 @@ using Reexport
 
 @reexport using DataFrames
 
-using MacroTools
-
 # Basics:
 export @with, @where, @orderby, @transform, @by, @based_on, @select
 
@@ -431,8 +429,6 @@ is performed at the group level.
 
 ```jldoctest
 julia> using DataFrames, DataFramesMeta, Statistics
-
-
 
 julia> d = DataFrame(n = 1:20, x = [3, 3, 3, 3, 1, 1, 1, 2, 1, 1,
                                     2, 1, 1, 2, 2, 2, 3, 1, 1, 2]);

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -268,6 +268,4 @@ end
 end
 
 
-@test DataFramesMeta.orderby(df, df[[1, 3, 2], :]) == df[[1, 3, 2], :]
-
 end # module

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -291,9 +291,6 @@ end
     @test @orderby(df, :c).i == [3, 1, 2, 4, 5]
     @test @orderby(df, -:g).i == [4, 5, 1, 2, 3]
     @test @orderby(df, :t).i == [1, 2, 3, 4, 5]
-
-    @test @orderby(gd, mean(:i)).i == [1, 2, 3, 4, 5]
-    @test @orderby(df, std(:i) .- :i).i == [5, 4, 3, 2, 1]
 end
 
 

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -267,5 +267,24 @@ end
     @test  @where(df, :A .> 1, :A .< 4, :B .> 1) == df[map(&, df.A .> 1, df.A .< 4, df.B .> 1),:]
 end
 
+@testset "orderby" begin
+    df = DataFrame(
+        g = [1, 1, 1, 2, 2],
+        i = 1:5,
+        t = ["a", "b", "c", "c", "e"],
+        y = [:v, :w, :x, :y, :z],
+        c = [:g, :quote, :body, :transform, missing]
+        )
+
+    gd = groupby(df, :g)
+
+    @test @orderby(df, :c).i == [3, 1, 2, 4, 5]
+    @test @orderby(df, -:g).i == [4, 5, 1, 2, 3]
+    @test @orderby(df, :t).i == [1, 2, 3, 4, 5]
+
+    @test @orderby(gd, mean(:i)).i == [1, 2, 3, 4, 5]
+    @test @orderby(df, std(:i) .- :i).i == [5, 4, 3, 2, 1]
+end
+
 
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -291,30 +291,4 @@ end
 	@test @select(g, :a, t = :c).a ≅ d.a
 end
 
-
-@testset "orderby with a grouped data frame" begin
-    df = DataFrame(
-        g = [1, 1, 1, 2, 2],
-        i = 1:5,
-        t = ["a", "b", "c", "c", "e"],
-        y = [:v, :w, :x, :y, :z],
-        c = [:g, :quote, :body, :transform, missing]
-        )
-
-    gd = groupby(df, :g)
-
-    @test @orderby(gd, mean(:i)).i ==
-        @orderby(@select(gd, :i, m = mean(:i)), :m).i ==
-        [1, 2, 3, 4, 5]
-
-    @test @orderby(gd, std(:i) .- :i).i ==
-        @orderby(@select(gd, :i, m = std(:i) .- :i), :m).i ==
-        [5, 4, 3, 2, 1]
-
-    @test @orderby(gd, :g, -1 .* (:i .- mean(:i))).i ==
-        @orderby(@select(gd, :i, m = -1 .* (:i .- mean(:i))), :g, :m).i ==
-        [3, 2, 1, 5, 4]
-end
-
-
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -14,10 +14,7 @@ g = groupby(d, :x, sort=true)
 @test  DataFrame(@where(g, length(:x) > 5)) == DataFrame(DataFramesMeta.where(g, x -> length(x.x) > 5))
 @test  DataFrame(@where(g, length(:x) > 5))[!, :n][1:3] == [5, 6, 7]
 
-@test  DataFrame(DataFramesMeta.orderby(g, x -> mean(x.n))) == DataFrame(@orderby(g, mean(:n)))
-
 @test @based_on(g, nsum = sum(:n)).nsum == [99, 84, 27]
-
 
 @testset "@based_on" begin
     df = DataFrame(

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -4,7 +4,6 @@ using Test
 using DataFrames
 using DataFramesMeta
 using Statistics
-using Tables
 
 const ≅ = isequal
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -303,9 +303,17 @@ end
 
     gd = groupby(df, :g)
 
-    @test @orderby(gd, mean(:i)).i == [1, 2, 3, 4, 5]
-    @test @orderby(df, std(:i) .- :i).i == [5, 4, 3, 2, 1]
-    @test @orderby(gd, :g, -1 .* (:i .- mean(:i))).i == [3, 2, 1, 5, 4]
+    @test @orderby(gd, mean(:i)).i ==
+        @orderby(@select(gd, :i, m = mean(:i)), :m).i ==
+        [1, 2, 3, 4, 5]
+
+    @test @orderby(gd, std(:i) .- :i).i ==
+        @orderby(@select(gd, :i, m = std(:i) .- :i), :m).i ==
+        [5, 4, 3, 2, 1]
+
+    @test @orderby(gd, :g, -1 .* (:i .- mean(:i))).i ==
+        @orderby(@select(gd, :i, m = -1 .* (:i .- mean(:i))), :g, :m).i ==
+        [3, 2, 1, 5, 4]
 end
 
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -291,4 +291,22 @@ end
 	@test @select(g, :a, t = :c).a ≅ d.a
 end
 
+
+@testset "orderby with a grouped data frame" begin
+    df = DataFrame(
+        g = [1, 1, 1, 2, 2],
+        i = 1:5,
+        t = ["a", "b", "c", "c", "e"],
+        y = [:v, :w, :x, :y, :z],
+        c = [:g, :quote, :body, :transform, missing]
+        )
+
+    gd = groupby(df, :g)
+
+    @test @orderby(gd, mean(:i)).i == [1, 2, 3, 4, 5]
+    @test @orderby(df, std(:i) .- :i).i == [5, 4, 3, 2, 1]
+    @test @orderby(gd, :g, -1 .* (:i .- mean(:i))).i == [3, 2, 1, 5, 4]
+end
+
+
 end # module

--- a/test/linqmacro.jl
+++ b/test/linqmacro.jl
@@ -39,8 +39,6 @@ xlinq2 = @linq df  |>
     groupby(:b) |>
     based_on(meanX = mean(:x), meanY = mean(:y))
 
-xlinq2[!, [:meanX, :meanY]] == xlinq[!, [:meanX, :meanY]]
-
 @test xlinq2[!, [:meanX, :meanY]] == xlinq[!, [:meanX, :meanY]]
 
 xlinq3 = @linq df  |>

--- a/test/linqmacro.jl
+++ b/test/linqmacro.jl
@@ -38,6 +38,7 @@ xlinq2 = @linq df  |>
     transform(y = 10 * :x)  |>
     groupby(:b) |>
     orderby(-mean(:x))  |>
+    groupby(:b) |>
     based_on(meanX = mean(:x), meanY = mean(:y))
 
 @test xlinq2[!, [:meanX, :meanY]] == xlinq[!, [:meanX, :meanY]]
@@ -47,6 +48,7 @@ xlinq3 = @linq df  |>
     transform(y = 10 * :x)  |>
     DataFrames.groupby(:b) |>
     orderby(-mean(:x))  |>
+    groupby(:b) |>
     based_on(meanX = mean(:x), meanY = mean(:y))
 
 @test xlinq3[!, [:meanX, :meanY]] == xlinq[!, [:meanX, :meanY]]
@@ -70,6 +72,7 @@ xlinq3 = @linq df  |>
         transform(cols(y_str) = 10 * cols(x_sym))  |>
         DataFrames.groupby(b_str) |>
         orderby(-mean(cols(x_sym)))  |>
+        groupby(:b) |>
         based_on(cols("meanX") = mean(:x), meanY = mean(:y))
 
     @test isequal(xlinq3, DataFrame(b = "d", meanX = 40.0, meanY = 400.0))

--- a/test/linqmacro.jl
+++ b/test/linqmacro.jl
@@ -12,20 +12,20 @@ df = DataFrame(a = repeat(1:5, outer = 20),
 
 x = @where(df, :a .> 2, :b .!= "c")
 x = @transform(x, y = 10 * :x)
+x = @orderby(x, :x .- mean(:x))
 x = @by(x, :b, meanX = mean(:x), meanY = mean(:y))
-x = @orderby(x, -:meanX)
 x = @select(x, var = :b, :meanX, :meanY)
 
 x1 = @linq transform(where(df, :a .> 2, :b .!= "c"), y = 10 * :x)
-x1 = @linq by(x1, :b, meanX = mean(:x), meanY = mean(:y))
-x1 = @linq select(orderby(x1, -:meanX), var = :b, :meanX, :meanY)
+x1 = @linq by(orderby(x1, :x .- mean(:x)), :b, meanX = mean(:x), meanY = mean(:y))
+x1 = @linq select(x1, var = :b, :meanX, :meanY)
 
 ## chaining
 xlinq = @linq df  |>
     where(:a .> 2, :b .!= "c")  |>
     transform(y = 10 * :x)  |>
+    orderby(:x .- mean(:x)) |>
     by(:b, meanX = mean(:x), meanY = mean(:y))  |>
-    orderby(-:meanX)  |>
     select(var = :b, :meanX, :meanY)
 
 @test x == x1
@@ -34,8 +34,7 @@ xlinq = @linq df  |>
 xlinq2 = @linq df  |>
     where(:a .> 2, :b .!= "c")  |>
     transform(y = 10 * :x)  |>
-    groupby(:b) |>
-    orderby(-mean(:x))  |>
+    orderby(:x .- mean(:x)) |>
     groupby(:b) |>
     based_on(meanX = mean(:x), meanY = mean(:y))
 
@@ -44,9 +43,8 @@ xlinq2 = @linq df  |>
 xlinq3 = @linq df  |>
     where(:a .> 2, :b .!= "c")  |>
     transform(y = 10 * :x)  |>
+    orderby(:x .- mean(:x)) |>
     DataFrames.groupby(:b) |>
-    orderby(-mean(:x))  |>
-    groupby(:b) |>
     based_on(meanX = mean(:x), meanY = mean(:y))
 
 @test xlinq3[!, [:meanX, :meanY]] == xlinq[!, [:meanX, :meanY]]

--- a/test/linqmacro.jl
+++ b/test/linqmacro.jl
@@ -41,6 +41,8 @@ xlinq2 = @linq df  |>
     groupby(:b) |>
     based_on(meanX = mean(:x), meanY = mean(:y))
 
+xlinq2[!, [:meanX, :meanY]] == xlinq[!, [:meanX, :meanY]]
+
 @test xlinq2[!, [:meanX, :meanY]] == xlinq[!, [:meanX, :meanY]]
 
 xlinq3 = @linq df  |>

--- a/test/linqmacro.jl
+++ b/test/linqmacro.jl
@@ -6,11 +6,9 @@ using DataFramesMeta
 using Statistics
 using Random
 
-Random.seed!(100)
-n = 100
-df = DataFrame(a = rand(1:3, n),
-               b = ["a","b","c","d"][rand(1:4, n)],
-               x = rand(n))
+df = DataFrame(a = repeat(1:5, outer = 20),
+               b = repeat(["a", "b", "c", "d"], inner = 25),
+               x = repeat(1:20, inner = 5))
 
 x = @where(df, :a .> 2, :b .!= "c")
 x = @transform(x, y = 10 * :x)

--- a/test/linqmacro.jl
+++ b/test/linqmacro.jl
@@ -66,9 +66,8 @@ xlinq3 = @linq df  |>
     xlinq3 = @linq df  |>
         where(cols(a_sym) .> 2, :b .!= "c")  |>
         transform(cols(y_str) = 10 * cols(x_sym))  |>
-        DataFrames.groupby(b_str) |>
-        orderby(-mean(cols(x_sym)))  |>
-        groupby(:b) |>
+        orderby(cols(x_sym) .- mean(cols(x_sym)))  |>
+        groupby(b_str) |>
         based_on(cols("meanX") = mean(:x), meanY = mean(:y))
 
     @test isequal(xlinq3, DataFrame(b = "d", meanX = 40.0, meanY = 400.0))


### PR DESCRIPTION
Before, there was some complicated `with_anonymous` machinery. 

Now the backends are `select` and `combine`. 

For an abstract data frame this is intuitive, just call `select` on all the arguments with a `nolhs = true` option and return the `sortperm` from that. 

For a grouped data frame, unfortunately `@orderby` currently re-orders the groups and returns a grouped dataframe. 

This annoying because if you do, say, 

```

julia> df = DataFrame(a = [1, 1, 2, 2], b = [6, 6, 7, 7]);

julia> gd = groupby(df, :a);

julia> @orderby(df, :b)
```

then the result of the anonymous function in `@orderby` is a vector for each group and since Julia has lexicographic ordering of vectors, you can get some surprising results. 

~This was never tested and I'm not sure who uses it. I am making a breaking change here by only allowing things inside `@orderby` to return scalars, i.e. `@orderby(df, :b)` will error, and `@orderby(df, mean(:b))` will work.~

Update: I have found a solution that is somewhat hacky but doable. Current behavior matches 100% old behavior. 