### PR TITLE
up DataFrames.jl dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-DataFrames = "0.21"
+DataFrames = "0.21, 0.22"
 Reexport = "0.2"
 julia = "1"
 


### PR DESCRIPTION
@pdeffebach - I guess DataFramesMeta.jl should work on 0.22 release of DataFrames.jl equally well. Right? How fare are you with the release of DataFramesMeta.jl? (it is holding back the update of the tutorials)