### PR TITLE
delete @> reference, add chain

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -427,11 +427,11 @@ df = DataFrame(a = repeat(1:5, outer = 20),
                x = repeat(1:20, inner = 5))
 
 x_thread = @chain df begin
-    @transform(_, y = 10 * :x)
-    @where(_, :a .> 2)
-    @by(_, :b, meanX = mean(:x), meanY = mean(:y))
-    @orderby(_, :meanX)
-    @select(_, :meanX, :meanY, var = :b)
+    @transform(y = 10 * :x)
+    @where(:a .> 2)
+    @by(:b, meanX = mean(:x), meanY = mean(:y))
+    @orderby(:meanX)
+    @select(:meanX, :meanY, var = :b)
 end
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -414,30 +414,26 @@ more obvious with less noise from `@` symbols. This approach also
 avoids filling up the limited macro name space. The main downside is
 that more magic happens under the hood.
 
-Alternatively you can use Lazy.jl `@>` macro like this:
+Alternatively you can use Chain.jl, which exports the `@chain` macro. With Chain.jl,
+there is no need for `|>` and the first result of the previous expression is 
+assumed to be the first argument of the current call, unless otherwise specified 
+with `_`.
 
 ```julia
-using Lazy: @>
+using Chain, Statistics
 
 df = DataFrame(a = repeat(1:5, outer = 20),
                b = repeat(["a", "b", "c", "d"], inner = 25),
                x = repeat(1:20, inner = 5))
 
-x_thread = @> begin
-    df
-    @transform(y = 10 * :x)
-    @where(:a .> 2)
-    @by(:b, meanX = mean(:x), meanY = mean(:y))
-    @orderby(:meanX)
-    @select(:meanX, :meanY, var = :b)
+x_thread = @chain df begin
+    @transform(_, y = 10 * :x)
+    @where(_, :a .> 2)
+    @by(_, :b, meanX = mean(:x), meanY = mean(:y))
+    @orderby(_, :meanX)
+    @select(_, :meanX, :meanY, var = :b)
 end
 ```
-
-!!! note 
-    Please note that Lazy exports the function `groupby` which would clash
-    with `DataFrames.groupby`. Hence, it is recommended that you only import a
-    select number of functions into the namespace by only importing `@>` e.g. 
-    `using Lazy: @>` instead of `using Lazy`.
 
 Another alternative is Pipe.jl which exports the `@pipe` macro for piping. 
 The piping mechanism in Pipe requires explicit specification of the piped
@@ -445,7 +441,7 @@ object via `_` instead of assuming it is the first argument to the next function
 The Pipe.jl equivalent of the above is:
 
 ```julia
-using Pipe
+using Pipe, Statistics
 
 df = DataFrame(a = repeat(1:5, outer = 20),
                b = repeat(["a", "b", "c", "d"], inner = 25),

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -415,7 +415,7 @@ avoids filling up the limited macro name space. The main downside is
 that more magic happens under the hood.
 
 Alternatively you can use Chain.jl, which exports the `@chain` macro. With Chain.jl,
-there is no need for `|>` and the first result of the previous expression is 
+there is no need for `|>` and the result of the previous expression is 
 assumed to be the first argument of the current call, unless otherwise specified 
 with `_`.
 


### PR DESCRIPTION
Another small chain, deleting the reference to Lazy's `@>` since it conflicts with `groupby`. Instead I discuss Chain.jl's `@chain` macro as an alternative to `@linq`. 