### PR TITLE
re-add reexport 0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 DataFrames = "0.21, 0.22"
-Reexport = "1"
+Reexport = "0.2, 1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
It seems there are some stragglers when it comes to updating re-export, see Blink.jl [here](https://github.com/JuliaGizmos/Blink.jl/issues/277). 

I recently tried to add FloatingTableView.jl with DataFramesMeta installed and it threw an incompatability. 

Better to be safe and re-allow the older versoin of Reexport. 