### PR TITLE
Fix of === after DataFrames PR

### DIFF
--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -148,7 +148,6 @@ end
 
     # non-copying
     @test @transform!(df, n = :i).g === df.g
-    @test @transform!(df, n = :i).n === df.i
     # mutating
     df2 = copy(df)
     @test @transform!(df, :i) === df


### PR DESCRIPTION
After https://github.com/JuliaData/DataFrames.jl/pull/2721, `transform!(df, :a => identity => :b)` will perform a copy. This is causing breaking tests. 