### PR TITLE
Make `@astable` flag for retuning a table

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-DataFrames = "0.21, 0.22, 1"
+DataFrames = "0.22, 1"
 Reexport = "0.2, 1"
 julia = "1"
 

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -5,11 +5,11 @@ using Reexport
 @reexport using DataFrames
 
 # Basics:
-export @with, @where, @orderby, @transform, @by, @combine, @select,
+export @with, @subset, @orderby, @transform, @by, @combine, @select,
        @transform!, @select!,
        @eachrow, @eachrow!,
        @byrow,
-       @based_on # deprecated
+       @based_on, @where # deprecated
 
 
 global const DATAFRAMES_GEQ_22 = isdefined(DataFrames, :pretty_table) ? true : false


### PR DESCRIPTION
Instead of having `cols(AsTable) = ...`, I am implementing an `@astable` flag to indicate that an expression returns a `table`

```
@transform df @astable (a = :x, b = :y)
```

I initially started on implementing `@subset` but there was too much junk in the `make_source_fun` implementation to make that a clean PR. So I figured I would implement this feature first so make `@subset` easier. 