### PR TITLE
Re-factor macro-flag handling, fix Table-returning paths, only allow DataFrames 0.22 and above

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,9 +9,9 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 DataFrames = "0.21, 0.22, 1"
+MacroTools = "0.5"
 Reexport = "0.2, 1"
 julia = "1"
-MacroTools = "0.5"
 
 [extras]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-DataFrames = "0.21, 0.22, 1"
+DataFrames = "0.22, 1"
 MacroTools = "0.5"
 Reexport = "0.2, 1"
 julia = "1"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -333,7 +333,7 @@ DataFrames.jl exports the data type `AsTable` which indicates that a transformat
 returns a Tables.jl-compatible object. DataFramesMeta.jl emulates this behavior
 with the macro-flag `@astable`. 
 
-For more information, see the [DataFramesMeta.@astable](@ref). 
+For more information, see the [API](@ref) section. 
 
 ## Working with column names programmatically with `cols`
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,7 +19,6 @@ In addition, DataFramesMeta provides
 * `@eachrow` and `@eachrow!` for looping through rows in data frame, again with high performance and 
   convenient syntax. 
 * `@byrow` for applying functions to each row of a data frame (only supported inside other macros).
-* `@astable` for signalling that a function returns a [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible object.
 * `@linq`, for piping the above macros together, similar to [magrittr](https://cran.r-project.org/web/packages/magrittr/vignettes/magrittr.html)'s
   `%>%` in R. 
 
@@ -326,17 +325,6 @@ however, like with `ByRow` in DataFrames.jl, when `@byrow` is
 used, functions do not take into account the grouping, so for
 example the result of `@transform(df, @byrow y = f(:x))` and 
 `@transform(groupby(df, :g), @byrow y = f(:x))` is the same.
-
-## Returning a Table with `@astable`
-
-Use the syntax `@astable` for transformations which return 
-table-like objects, such as `NamedTuple`s. This is the DataFramesMeta.jl
-equivelent of the `AsTable` syntax in DataFrames.jl.
-
-`@astable` can be used inside `@transform`, `@transform!`,
-`@select`, `@select!`, `@combine`, and `@by`.
-
-For more information, see the [API](@ref) section. 
 
 ## Working with column names programmatically with `cols`
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,6 +19,7 @@ In addition, DataFramesMeta provides
 * `@eachrow` and `@eachrow!` for looping through rows in data frame, again with high performance and 
   convenient syntax. 
 * `@byrow` for applying functions to each row of a data frame (only supported inside other macros).
+* `@astable` for signalling that a function returns a [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible object.
 * `@linq`, for piping the above macros together, similar to [magrittr](https://cran.r-project.org/web/packages/magrittr/vignettes/magrittr.html)'s
   `%>%` in R. 
 
@@ -325,6 +326,14 @@ however, like with `ByRow` in DataFrames.jl, when `@byrow` is
 used, functions do not take into account the grouping, so for
 example the result of `@transform(df, @byrow y = f(:x))` and 
 `@transform(groupby(df, :g), @byrow y = f(:x))` is the same.
+
+## Returning a Table with `@astable`
+
+DataFrames.jl exports the data type `AsTable` which indicates that a transformation
+returns a Tables.jl-compatible object. DataFramesMeta.jl emulates this behavior
+with the macro-flag `@astable`. 
+
+For more information, see the [DataFramesMeta.@astable](@ref). 
 
 ## Working with column names programmatically with `cols`
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -329,9 +329,12 @@ example the result of `@transform(df, @byrow y = f(:x))` and
 
 ## Returning a Table with `@astable`
 
-DataFrames.jl exports the data type `AsTable` which indicates that a transformation
-returns a Tables.jl-compatible object. DataFramesMeta.jl emulates this behavior
-with the macro-flag `@astable`. 
+Use the syntax `@astable` for transformations which return 
+table-like objects, such as `NamedTuple`s. This is the DataFramesMeta.jl
+equivelent of the `AsTable` syntax in DataFrames.jl.
+
+`@astable` can be used inside `@transform`, `@transform!`,
+`@select`, `@select!`, `@combine`, and `@by`.
 
 For more information, see the [API](@ref) section. 
 

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -10,7 +10,7 @@ using MacroTools
 export @with, @where, @orderby, @transform, @by, @combine, @select,
        @transform!, @select!,
        @eachrow, @eachrow!,
-       @byrow,
+       @byrow, @astable,
        @based_on # deprecated
 
 

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -10,7 +10,7 @@ using MacroTools
 export @with, @where, @orderby, @transform, @by, @combine, @select,
        @transform!, @select!,
        @eachrow, @eachrow!,
-       @byrow, @astable,
+       @byrow,
        @based_on # deprecated
 
 

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -13,9 +13,6 @@ export @with, @where, @orderby, @transform, @by, @combine, @select,
        @byrow,
        @based_on # deprecated
 
-
-global const DATAFRAMES_GEQ_22 = isdefined(DataFrames, :pretty_table) ? true : false
-
 include("parsing.jl")
 include("macros.jl")
 include("linqmacro.jl")

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -837,7 +837,7 @@ end
 
 astable_docstring = """
 The `@astable` flag can be used for transformations that return
-Tables-jl compatible objects, such as `NamedTuple`s of `Vector`s.
+Tables.jl compatible objects, such as `NamedTuple`s of `Vector`s.
 When combined with `@byrow`, transformations marked with `@astable`
 must return row-like objects, such as `NamedTuple`s of scalars or
 `Vector`s.

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -284,6 +284,54 @@ end
 
 ##############################################################################
 ##
+## @astable
+##
+##############################################################################
+
+"""
+    @astable
+
+An internal flag inside DataFramesMeta.jl macros to indicate
+that a transformation returns a Tables.jl-compatible object.
+
+`@astable` is not a "real" Julia macro but rather serves as a "flag"
+to indicate that the `dest` in the `source => fun => dest` expression
+within DataFramesMeta should be `AsTable`. For example, the expression
+
+```
+@transform(df, @astable (x = :a, y = :b))
+```
+
+is equivalent to
+
+```
+transform(df, [:a, :b] => ((a, b) -> (x = a, y = b)) => AsTable)
+```
+
+`@astable` is most useful in `@combine` and `@by`
+
+### Examples
+
+```
+julia> df = DataFrame(a = [1, 1, 2, 2], b = [4, 5, 6, 7]);
+
+julia> @by df :a @astable begin
+           (firstb = first(:b), lastb = last(:b))
+       end
+2×3 DataFrame
+ Row │ a      firstb  lastb
+     │ Int64  Int64   Int64
+─────┼──────────────────────
+   1 │     1       4      5
+   2 │     2       6      7
+```
+"""
+macro astable(args...)
+    throw(ArgumentError("@astable is only allowed inside DataFramesMeta macros."))
+end
+
+##############################################################################
+##
 ## @with
 ##
 ##############################################################################

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -113,11 +113,6 @@ julia> @where df @byrow begin
    1 │     2      4
 ```
 
-`@byrow` can be combined with `@astable` in the same way
-that in DataFrames.jl `AsTable` can be combined with
-`ByRow`. The returned object must be a `NamedTuple`,
-a vector, or other "row-like" object.
-
 ### Comparison with `@eachrow`
 
 To re-cap, the `@eachrow` macro roughly transforms
@@ -287,71 +282,6 @@ macro byrow(args...)
     throw(ArgumentError("@byrow is deprecated outside of DataFramesMeta macros."))
 end
 
-##############################################################################
-##
-## @astable
-##
-##############################################################################
-
-"""
-    @astable
-
-An internal flag inside DataFramesMeta.jl macros to indicate
-that a transformation returns a Tables.jl-compatible object.
-
-`@astable` is not a "real" Julia macro but rather serves as a "flag"
-to indicate that the `dest` in the `source => fun => dest` expression
-within DataFramesMeta should be `AsTable`. For example, the expression
-
-```
-@transform(df, @astable (x = :a, y = :b))
-```
-
-is equivalent to
-
-```
-transform(df, [:a, :b] => ((a, b) -> (x = a, y = b)) => AsTable)
-```
-
-`@astable` is especially useful in `@combine` and `@by` for
-generating summary statistics by group.
-
-`@astable` can be combined with `@byrow` in the same way
-that in DataFrames.jl `AsTable` can be combined with
-`ByRow`. The returned object must be a `NamedTuple`,
-a vector, or other "row-like" object.
-
-### Examples
-
-```
-julia> df = DataFrame(a = [1, 1, 2, 2], b = [4, 5, 6, 7]);
-
-julia> @by df :a @astable begin
-           (firstb = first(:b), lastb = last(:b))
-       end
-2×3 DataFrame
- Row │ a      firstb  lastb
-     │ Int64  Int64   Int64
-─────┼──────────────────────
-   1 │     1       4      5
-   2 │     2       6      7
-
-julia> df = DataFrame(a = [1, 1, 2, 2], b = [4, 5, 6, 7]);
-
-julia> @transform df @byrow @astable (x = :a + 1, y = :b - 1)
-4×4 DataFrame
- Row │ a      b      x      y
-     │ Int64  Int64  Int64  Int64
-─────┼────────────────────────────
-   1 │     1      4      2      3
-   2 │     1      5      2      4
-   3 │     2      6      3      5
-   4 │     2      7      3      6
-```
-"""
-macro astable(args...)
-    throw(ArgumentError("@astable is only allowed inside DataFramesMeta macros."))
-end
 
 ##############################################################################
 ##
@@ -835,13 +765,6 @@ end
 ##
 ##############################################################################
 
-astable_docstring = """
-The `@astable` flag can be used for transformations that return
-Tables.jl compatible objects, such as `NamedTuple`s of `Vector`s.
-When combined with `@byrow`, transformations marked with `@astable`
-must return row-like objects, such as `NamedTuple`s of scalars or
-`Vector`s.
-"""
 
 function transform_helper(x, args...)
     exprs, wrap_byrow = create_args_vector(args...)
@@ -906,8 +829,6 @@ transformations by row, `@transform` allows `@byrow` at the
 beginning of a block of transformations (i.e. `@byrow begin... end`).
 All transformations in the block will operate by row.
 
-$astable_docstring
-
 ### Examples
 
 ```jldoctest
@@ -949,16 +870,6 @@ julia> @transform df @byrow begin
    2 │     2      1      2    200
    3 │     3      2      6    200
 
-julia> @transform df @astable begin
-           (A1 = :A .+ 1, B1 = :B .+ 1)
-       end
-3×4 DataFrame
- Row │ A      B      A1     B1
-     │ Int64  Int64  Int64  Int64
-─────┼────────────────────────────
-   1 │     1      2      2      3
-   2 │     2      1      3      2
-   3 │     3      2      4      3
 ```
 """
 macro transform(x, args...)
@@ -1036,8 +947,6 @@ To avoid writing `@byrow` multiple times when performing multiple
 transform!ations by row, `@transform!` allows `@byrow` at the
 beginning of a block of transform!ations (i.e. `@byrow begin... end`).
 All transform!ations in the block will operate by row.
-
-$astable_docstring
 
 ### Examples
 
@@ -1134,8 +1043,6 @@ transformations by row, `@select` allows `@byrow` at the
 beginning of a block of selectations (i.e. `@byrow begin... end`).
 All transformations in the block will operate by row.
 
-$astable_docstring
-
 ### Examples
 
 ```jldoctest
@@ -1173,23 +1080,6 @@ julia> @select df begin
    6 │     6      7
    7 │     7      9
    8 │     8      9
-
-julia> @select df @astable begin
-           (a1 = :a .+ 1, b2 = :b .+ 1)
-       end
-
-8×2 DataFrame
- Row │ a1     b2
-     │ Int64  Int64
-─────┼──────────────
-   1 │     2      3
-   2 │     3      2
-   3 │     4      3
-   4 │     5      2
-   5 │     2      3
-   6 │     3      2
-   7 │     4      3
-   8 │     5      2
 ```
 """
 macro select(x, args...)
@@ -1253,8 +1143,6 @@ To avoid writing `@byrow` multiple times when performing multiple
 transformations by row, `@select!` allows `@byrow` at the
 beginning of a block of select!ations (i.e. `@byrow begin... end`).
 All transformations in the block will operate by row.
-
-$astable_docstring
 
 ### Examples
 
@@ -1322,12 +1210,11 @@ function combine_helper(x, args...; deprecation_warning = false)
     fe = first(exprs)
     if length(exprs) == 1 &&
         !(fe isa QuoteNode || onearg(fe, :cols)) &&
-        !(fe.head == :(=) || fe.head == :kw) &&
-        !(fe.args[1] == Symbol("@astable"))
+        !(fe.head == :(=) || fe.head == :kw)
 
-        @warn "Returning a Table object from @by and @combine now requires an explicit @astable flag"
+        @warn "Returning a Table object from @by and @combine now requires `cols(AsTable)` on the LHS."
 
-        exprs = ((:(@astable $fe)),)
+        exprs = ((:(cols(AsTable) = $fe)),)
     end
 
     t = (fun_to_vec(ex; gensym_names = false, wrap_byrow = wrap_byrow) for ex in exprs)
@@ -1364,8 +1251,6 @@ and
 ```
 @combine(df, mx = mean(:x), sx = std(:x))
 ```
-
-$astable_docstring
 
 ### Examples
 
@@ -1416,14 +1301,6 @@ julia> @combine g begin
   19 │     3      6     27
   20 │     3      6     27
 
-julia> @combine g @astable (n_sum = sum(:n), n_min = minimum(:n))
-3×3 DataFrame
- Row │ x      n_sum  n_min
-     │ Int64  Int64  Int64
-─────┼─────────────────────
-   1 │     1     99      5
-   2 │     2     84      8
-   3 │     3     27      1
 ```
 """
 macro combine(x, args...)
@@ -1453,12 +1330,11 @@ function by_helper(x, what, args...)
     fe = first(exprs)
     if length(exprs) == 1 &&
         !(fe isa QuoteNode || onearg(fe, :cols)) &&
-        !(fe.head == :(=) || fe.head == :kw) &&
-        !(fe.args[1] == Symbol("@astable"))
+        !(fe.head == :(=) || fe.head == :kw)
 
-        @warn "Returning a Table object from @by and @combine now requires an explicit @astable flag"
+        @warn "Returning a Table object from @by and @combine now requires `cols(AsTable)` on the LHS."
 
-        exprs = ((:(@astable $fe)),)
+        exprs = ((:(cols(AsTable) = $fe)),)
     end
 
     t = (fun_to_vec(ex; gensym_names = false, wrap_byrow = wrap_byrow) for ex in exprs)
@@ -1467,7 +1343,6 @@ function by_helper(x, what, args...)
         $DataFrames.combine($groupby($x, $what), $(t...))
     end
 end
-
 
 """
     @by(d::AbstractDataFrame, cols, e...)
@@ -1501,8 +1376,6 @@ and
 ```
 @by(df, :g, mx = mean(:x), sx = std(:x))
 ```
-
-$astable_docstring
 
 ### Examples
 
@@ -1567,17 +1440,6 @@ julia> @by df :a begin
    7 │     4      4      6.0
    8 │     4      8      6.0
 
-julia> @by df :a @astable begin
-           (c_sum = first(:c), c_mean = mean(:c))
-       end
-4×3 DataFrame
- Row │ a      c_sum  c_mean
-     │ Int64  Int64  Float64
-─────┼───────────────────────
-   1 │     1      1      3.0
-   2 │     2      2      4.0
-   3 │     3      3      5.0
-   4 │     4      4      6.0
 ```
 """
 macro by(x, what, args...)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -294,6 +294,7 @@ function exec(df, p::Pair)
     fun = last(p)
     fun(map(c -> DataFramesMeta.getsinglecolumn(df, c), cols)...)
 end
+exec(df, s::Union{Symbol, AbstractString}) = df[!, s]
 
 getsinglecolumn(df, s::DataFrames.ColumnIndex) = df[!, s]
 getsinglecolumn(df, s) = throw(ArgumentError("Only indexing with Symbols, strings and integers " *

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -322,7 +322,7 @@ function fun_to_vec(ex::Expr; gensym_names::Bool=false, no_dest::Bool=false, wra
 
     throw(ArgumentError("This path should not be reached"))
 end
-fun_to_vec(ex::QuoteNode; no_dest::Bool=true, gensym_names::Bool=false, wrap_byrow::Bool=false) = ex
+fun_to_vec(ex::QuoteNode; no_dest::Bool=false, gensym_names::Bool=false, wrap_byrow::Bool=false) = ex
 
 function make_source_concrete(x::AbstractVector)
     if isempty(x) || isconcretetype(eltype(x))

--- a/test/astable.jl
+++ b/test/astable.jl
@@ -7,7 +7,7 @@ using Statistics
 
 const ≅ = isequal
 
-@testset "@transform with @astable" begin
+@testset "@transform with cols(AsTable)" begin
     df = DataFrame(
         g = [1, 1, 1, 2, 2],
         i = 1:5,
@@ -15,23 +15,23 @@ const ≅ = isequal
         y = [:v, :w, :x, :y, :z],
         c = [:g, :quote, :body, :transform, missing])
 
-    d = @transform df @astable (a = 1, b = 2)
+    d = @transform df cols(AsTable) =  (a = 1, b = 2)
 
     @test d ≅ transform(df, [] => (() -> (a = 1, b = 2)) => AsTable)
 
-    d = @transform df @astable (a = :i, b = :g)
+    d = @transform df cols(AsTable) =  (a = :i, b = :g)
 
     @test d.a == df.i
 
     d = @transform df begin
         a = 1
-        @astable (a1 = :i, a2 = :g)
+        cols(AsTable) =  (a1 = :i, a2 = :g)
     end
 
     @test d.a1 == df.i
 end
 
-@testset "@select with @astable" begin
+@testset "@select with cols(AsTable) = " begin
     df = DataFrame(
         g = [1, 1, 1, 2, 2],
         i = 1:5,
@@ -39,23 +39,23 @@ end
         y = [:v, :w, :x, :y, :z],
         c = [:g, :quote, :body, :transform, missing])
 
-    d = @select df @astable (a = 1, b = 2)
+    d = @select df cols(AsTable) =  (a = 1, b = 2)
 
     @test d ≅ select(df, [] => (() -> (a = 1, b = 2)) => AsTable)
 
-    d = @select df @astable (a = :i, b = :g)
+    d = @select df cols(AsTable) =  (a = :i, b = :g)
 
     @test d.a == df.i
 
     d = @select df begin
         a = 1
-        @astable (a1 = :i, a2 = :g)
+        cols(AsTable) =  (a1 = :i, a2 = :g)
     end
 
     @test d.a1 == df.i
 end
 
-@testset "@transform! with @astable" begin
+@testset "@transform! with cols(AsTable) = " begin
     df = DataFrame(
         g = [1, 1, 1, 2, 2],
         i = 1:5,
@@ -63,23 +63,23 @@ end
         y = [:v, :w, :x, :y, :z],
         c = [:g, :quote, :body, :transform, missing])
 
-    d = @transform! copy(df) @astable (a = 1, b = 2)
+    d = @transform! copy(df) cols(AsTable) =  (a = 1, b = 2)
 
     @test d ≅ transform(df, [] => (() -> (a = 1, b = 2)) => AsTable)
 
-    d = @transform! copy(df) @astable (a = :i, b = :g)
+    d = @transform! copy(df) cols(AsTable) =  (a = :i, b = :g)
 
     @test d.a == df.i
 
     d = @transform! copy(df) begin
         a = 1
-        @astable (a1 = :i, a2 = :g)
+        cols(AsTable) =  (a1 = :i, a2 = :g)
     end
 
     @test d.a1 == df.i
 end
 
-@testset "@select! with @astable" begin
+@testset "@select! with cols(AsTable) = " begin
     df = DataFrame(
         g = [1, 1, 1, 2, 2],
         i = 1:5,
@@ -87,23 +87,23 @@ end
         y = [:v, :w, :x, :y, :z],
         c = [:g, :quote, :body, :transform, missing])
 
-    d = @select! copy(df) @astable (a = 1, b = 2)
+    d = @select! copy(df) cols(AsTable) =  (a = 1, b = 2)
 
     @test d ≅ select(df, [] => (() -> (a = 1, b = 2)) => AsTable)
 
-    d = @select! copy(df) @astable (a = :i, b = :g)
+    d = @select! copy(df) cols(AsTable) =  (a = :i, b = :g)
 
     @test d.a == df.i
 
     d = @select! copy(df) begin
         a = 1
-        @astable (a1 = :i, a2 = :g)
+        cols(AsTable) =  (a1 = :i, a2 = :g)
     end
 
     @test d.a1 == df.i
 end
 
-@testset "@combine with @astable" begin
+@testset "@combine with cols(AsTable) = " begin
     df = DataFrame(
         g = [1, 1, 1, 2, 2],
         i = 1:5,
@@ -113,23 +113,23 @@ end
 
     g = groupby(df, :g)
 
-    d = @combine g @astable (a = 1, b = 2)
+    d = @combine g cols(AsTable) =  (a = 1, b = 2)
 
     @test d ≅ combine(g, [] => (() -> (a = 1, b = 2)) => AsTable)
 
-    d = @combine df @astable (a = first(:i), b = first(:g))
+    d = @combine df cols(AsTable) =  (a = first(:i), b = first(:g))
 
     @test d == DataFrame(a = 1, b = 1)
 
     d = @combine df begin
         a = 1
-        @astable (a1 = 1, a2 = 2)
+        cols(AsTable) =  (a1 = 1, a2 = 2)
     end
 
     @test d == DataFrame(a = 1, a1 = 1, a2 = 2)
 end
 
-@testset "@by with @astable" begin
+@testset "@by with cols(AsTable) = " begin
     df = DataFrame(
         g = [1, 1, 1, 2, 2],
         i = 1:5,
@@ -139,7 +139,7 @@ end
 
     g = groupby(df, :g)
 
-    d = @by df :g @astable (a = 1, b = 2)
+    d = @by df :g cols(AsTable) =  (a = 1, b = 2)
 
     @test d ≅ combine(groupby(df, :g), [] => (() -> (a = 1, b = 2)) => AsTable)
 end

--- a/test/astable.jl
+++ b/test/astable.jl
@@ -1,0 +1,147 @@
+module Testbyrow
+
+using Test
+using DataFrames
+using DataFramesMeta
+using Statistics
+
+const ≅ = isequal
+
+@testset "@transform with @astable" begin
+    df = DataFrame(
+        g = [1, 1, 1, 2, 2],
+        i = 1:5,
+        t = ["a", "b", "c", "c", "e"],
+        y = [:v, :w, :x, :y, :z],
+        c = [:g, :quote, :body, :transform, missing])
+
+    d = @transform df @astable (a = 1, b = 2)
+
+    @test d ≅ transform(df, [] => (() -> (a = 1, b = 2)) => AsTable)
+
+    d = @transform df @astable (a = :i, b = :g)
+
+    @test d.a == df.i
+
+    d = @transform df begin
+        a = 1
+        @astable (a1 = :i, a2 = :g)
+    end
+
+    @test d.a1 == df.i
+end
+
+@testset "@select with @astable" begin
+    df = DataFrame(
+        g = [1, 1, 1, 2, 2],
+        i = 1:5,
+        t = ["a", "b", "c", "c", "e"],
+        y = [:v, :w, :x, :y, :z],
+        c = [:g, :quote, :body, :transform, missing])
+
+    d = @select df @astable (a = 1, b = 2)
+
+    @test d ≅ select(df, [] => (() -> (a = 1, b = 2)) => AsTable)
+
+    d = @select df @astable (a = :i, b = :g)
+
+    @test d.a == df.i
+
+    d = @select df begin
+        a = 1
+        @astable (a1 = :i, a2 = :g)
+    end
+
+    @test d.a1 == df.i
+end
+
+@testset "@transform! with @astable" begin
+    df = DataFrame(
+        g = [1, 1, 1, 2, 2],
+        i = 1:5,
+        t = ["a", "b", "c", "c", "e"],
+        y = [:v, :w, :x, :y, :z],
+        c = [:g, :quote, :body, :transform, missing])
+
+    d = @transform! copy(df) @astable (a = 1, b = 2)
+
+    @test d ≅ transform(df, [] => (() -> (a = 1, b = 2)) => AsTable)
+
+    d = @transform! copy(df) @astable (a = :i, b = :g)
+
+    @test d.a == df.i
+
+    d = @transform! copy(df) begin
+        a = 1
+        @astable (a1 = :i, a2 = :g)
+    end
+
+    @test d.a1 == df.i
+end
+
+@testset "@select! with @astable" begin
+    df = DataFrame(
+        g = [1, 1, 1, 2, 2],
+        i = 1:5,
+        t = ["a", "b", "c", "c", "e"],
+        y = [:v, :w, :x, :y, :z],
+        c = [:g, :quote, :body, :transform, missing])
+
+    d = @select! copy(df) @astable (a = 1, b = 2)
+
+    @test d ≅ select(df, [] => (() -> (a = 1, b = 2)) => AsTable)
+
+    d = @select! copy(df) @astable (a = :i, b = :g)
+
+    @test d.a == df.i
+
+    d = @select! copy(df) begin
+        a = 1
+        @astable (a1 = :i, a2 = :g)
+    end
+
+    @test d.a1 == df.i
+end
+
+@testset "@combine with @astable" begin
+    df = DataFrame(
+        g = [1, 1, 1, 2, 2],
+        i = 1:5,
+        t = ["a", "b", "c", "c", "e"],
+        y = [:v, :w, :x, :y, :z],
+        c = [:g, :quote, :body, :transform, missing])
+
+    g = groupby(df, :g)
+
+    d = @combine g @astable (a = 1, b = 2)
+
+    @test d ≅ combine(g, [] => (() -> (a = 1, b = 2)) => AsTable)
+
+    d = @combine df @astable (a = first(:i), b = first(:g))
+
+    @test d == DataFrame(a = 1, b = 1)
+
+    d = @combine df begin
+        a = 1
+        @astable (a1 = 1, a2 = 2)
+    end
+
+    @test d == DataFrame(a = 1, a1 = 1, a2 = 2)
+end
+
+@testset "@by with @astable" begin
+    df = DataFrame(
+        g = [1, 1, 1, 2, 2],
+        i = 1:5,
+        t = ["a", "b", "c", "c", "e"],
+        y = [:v, :w, :x, :y, :z],
+        c = [:g, :quote, :body, :transform, missing])
+
+    g = groupby(df, :g)
+
+    d = @by df :g @astable (a = 1, b = 2)
+
+    @test d ≅ combine(groupby(df, :g), [] => (() -> (a = 1, b = 2)) => AsTable)
+end
+
+end

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -589,6 +589,10 @@ end
     @test  x == sum(df.A .* df.B)
     @test  @with(df, df[:A .> 1, ^([:B, :A])]) == df[df.A .> 1, [:B, :A]]
     @test  @with(df, DataFrame(a = :A * 2, b = :A .+ :B)) == DataFrame(a = df.A * 2, b = df.A .+ df.B)
+
+    @test @with(df, :a) === df.a
+    @test @with(df, cols(:a)) === df.a
+    @test @with(df, cols("a")) === df.a
 end
 
 @testset "where" begin

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -590,9 +590,9 @@ end
     @test  @with(df, df[:A .> 1, ^([:B, :A])]) == df[df.A .> 1, [:B, :A]]
     @test  @with(df, DataFrame(a = :A * 2, b = :A .+ :B)) == DataFrame(a = df.A * 2, b = df.A .+ df.B)
 
-    @test @with(df, :a) === df.a
-    @test @with(df, cols(:a)) === df.a
-    @test @with(df, cols("a")) === df.a
+    @test @with(df, :A) === df.A
+    @test @with(df, cols(:A)) === df.A
+    @test @with(df, cols("A")) === df.A
 end
 
 @testset "where" begin

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -151,13 +151,6 @@ gd = groupby(df, :g)
 newvar = :n
 
 @testset "Limits of @combine" begin
-    t = @combine(gd, [:i, :g])[!, 2]
-    @test t == [[1, 2, 3], [1, 1, 1], [4, 5], [2, 2]]
-    @test t isa Vector{SubArray{Int64,1,Array{Int64,1},Tuple{Array{Int64,1}},false}}
-    @test @combine(gd, All()).function isa Vector{<:All}
-    @test @combine(gd, Not(:i)).i_function isa Vector{<:InvertedIndex}
-    @test @combine(gd, Not([:i, :g])).g == [1, 2]
-
     @test_throws MethodError @eval @combine(gd, n = sum(Between(:i, :t)))
     @test_throws LoadError @eval @combine(gd; n = mean(:i))
     @test_throws ArgumentError @eval @combine(gd, n = mean(:i) + mean(cols(1)))
@@ -301,13 +294,6 @@ gd = groupby(df, :g)
 newvar = :n
 
 @testset "limits of @by" begin
-    t = @by(df, :g, [:i, :g])[!, 2]
-    @test t == [[1, 2, 3], [1, 1, 1], [4, 5], [2, 2]]
-    @test t isa Vector{SubArray{Int64,1,Array{Int64,1},Tuple{Array{Int64,1}},false}}
-    @test @by(df, :g, All()).function isa Vector{<:All}
-    @test @by(df, :g, Not(:i)).i_function isa Vector{<:InvertedIndex}
-    @test @by(df, :g, Not([:i, :g])).g == [1, 2]
-
     @test_throws MethodError @eval @by(df, :g, n = sum(Between(:i, :t)))
     @test_throws MethodError @eval @by(df, :g; n = mean(:i))
     @test_throws ArgumentError @eval @by(df, :g, n = mean(:i) + mean(cols(1)))

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -151,19 +151,13 @@ gd = groupby(df, :g)
 newvar = :n
 
 @testset "Limits of @combine" begin
-    if DataFramesMeta.DATAFRAMES_GEQ_22
-        @test_throws ArgumentError @combine(gd, [:i, :g])
-        @test_throws ArgumentError @combine(gd, All()).function isa Vector{<:All}
-        @test_throws ArgumentError @combine(gd, Not(:i)).i_function isa Vector{<:InvertedIndex}
-        @test_throws ArgumentError @combine(gd, Not([:i, :g])).g == [1, 2]
-    else
-        t = @combine(gd, [:i, :g])[!, 2]
-        @test t == [[1, 2, 3], [1, 1, 1], [4, 5], [2, 2]]
-        @test t isa Vector{SubArray{Int64,1,Array{Int64,1},Tuple{Array{Int64,1}},false}}
-        @test @combine(gd, All()).function isa Vector{<:All}
-        @test @combine(gd, Not(:i)).i_function isa Vector{<:InvertedIndex}
-        @test @combine(gd, Not([:i, :g])).g == [1, 2]
-    end
+    t = @combine(gd, [:i, :g])[!, 2]
+    @test t == [[1, 2, 3], [1, 1, 1], [4, 5], [2, 2]]
+    @test t isa Vector{SubArray{Int64,1,Array{Int64,1},Tuple{Array{Int64,1}},false}}
+    @test @combine(gd, All()).function isa Vector{<:All}
+    @test @combine(gd, Not(:i)).i_function isa Vector{<:InvertedIndex}
+    @test @combine(gd, Not([:i, :g])).g == [1, 2]
+
     @test_throws MethodError @eval @combine(gd, n = sum(Between(:i, :t)))
     @test_throws LoadError @eval @combine(gd; n = mean(:i))
     @test_throws ArgumentError @eval @combine(gd, n = mean(:i) + mean(cols(1)))
@@ -307,19 +301,13 @@ gd = groupby(df, :g)
 newvar = :n
 
 @testset "limits of @by" begin
-    if DataFramesMeta.DATAFRAMES_GEQ_22
-        @test_throws ArgumentError @by(df, :g, [:i, :g])
-        @test_throws ArgumentError @by(df, :g, All()).function isa Vector{<:All}
-        @test_throws ArgumentError @by(df, :g, Not(:i)).i_function isa Vector{<:InvertedIndex}
-        @test_throws ArgumentError @by(df, :g, Not([:i, :g])).g == [1, 2]
-    else
-        t = @by(df, :g, [:i, :g])[!, 2]
-        @test t == [[1, 2, 3], [1, 1, 1], [4, 5], [2, 2]]
-        @test t isa Vector{SubArray{Int64,1,Array{Int64,1},Tuple{Array{Int64,1}},false}}
-        @test @by(df, :g, All()).function isa Vector{<:All}
-        @test @by(df, :g, Not(:i)).i_function isa Vector{<:InvertedIndex}
-        @test @by(df, :g, Not([:i, :g])).g == [1, 2]
-    end
+    t = @by(df, :g, [:i, :g])[!, 2]
+    @test t == [[1, 2, 3], [1, 1, 1], [4, 5], [2, 2]]
+    @test t isa Vector{SubArray{Int64,1,Array{Int64,1},Tuple{Array{Int64,1}},false}}
+    @test @by(df, :g, All()).function isa Vector{<:All}
+    @test @by(df, :g, Not(:i)).i_function isa Vector{<:InvertedIndex}
+    @test @by(df, :g, Not([:i, :g])).g == [1, 2]
+
     @test_throws MethodError @eval @by(df, :g, n = sum(Between(:i, :t)))
     @test_throws MethodError @eval @by(df, :g; n = mean(:i))
     @test_throws ArgumentError @eval @by(df, :g, n = mean(:i) + mean(cols(1)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,9 @@ my_tests = ["dataframes.jl",
             "function_compilation.jl",
             "chaining.jl",
             "linqmacro.jl",
-            "deprecated.jl"]
+            "deprecated.jl",
+            "byrow.jl",
+            "astable.jl"]
 
 println("Running tests:")
 


### PR DESCRIPTION
This PR implements the following syntax

```
julia> df = DataFrame(a = [1, 2, 3], b = [4, 5, 6]);

julia> @transform df @astable (x = :a, y = :b)
3×4 DataFrame
 Row │ a      b      x      y     
     │ Int64  Int64  Int64  Int64 
─────┼────────────────────────────
   1 │     1      4      1      4
   2 │     2      5      2      5
   3 │     3      6      3      6
```

It also re-configures the way we treat macro flags so it will be easier to generalize flags in the future. 

I still need to add docs and tests. 