### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFramesMeta"
 uuid = "1313f7d8-7da2-5740-9ea0-a2ca25f37964"
-version = "0.7.1"
+version = "0.8.0"
 
 [deps]
 Chain = "8be319e6-bccf-4806-a6f7-6fae938471bc"


### PR DESCRIPTION
This version will  have 

* `@subset`
* `:y` on LHS instead of `:x`
* A small deprecation about `@combine` returning a table object. 