### PR TITLE
Fix `@where` deprecation warning

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -303,7 +303,7 @@ The following macros accept `@byrow`:
 * `@transform` and `@transform!`, `@select`, `@select!`, and `@combine`. 
   `@byrow` can be used in the left hand side of expressions, e.g.
   `@select(df, @byrow z = :x * :y)`. 
-* `@subset`, `@subset!` and `@orderby`, with syntax of the form `@where(df, @byrow :x > :y)`
+* `@subset`, `@subset!` and `@orderby`, with syntax of the form `@subset(df, @byrow :x > :y)`
 * `@with`, where the anonymous function created by `@with` is wrapped in
   `ByRow`, as in `@with(df, @byrow :x * :y)`.
 
@@ -312,7 +312,7 @@ operations, it is allowed to use`@byrow` at the beginning of a block of
 operations. All transformations in the block will operate by row.
 
 ```julia
-julia> @where df @byrow begin 
+julia> @subset df @byrow begin
            :a > 1
            :b < 5
        end
@@ -446,7 +446,7 @@ functions.
 
     Julia             dplyr            LINQ
     ---------------------------------------------
-    @where            filter           Where
+    @subset           filter           Where
     @transform        mutate           Select (?)
     @by                                GroupBy
     groupby           group_by         GroupBy
@@ -470,7 +470,7 @@ df = DataFrame(a = repeat(1:5, outer = 20),
 
 x_thread = @chain df begin
     @transform(:y = 10 * :x)
-    @where(:a .> 2)
+    @subset(:a .> 2)
     @by(:b, :meanX = mean(:x), :meanY = mean(:y))
     @orderby(:meanX)
     @select(:meanX, :meanY, :var = :b)
@@ -488,7 +488,7 @@ expression.
 # a few transformations
 @chain df begin 
     @transform(:y = 10 .* :x)
-    @where(:a .> 2)
+    @subset(:a .> 2)
     @select(:a, :y, :x)
     reduce(+, eachcol(_))
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -583,7 +583,7 @@ end
 Deprecated version of `@subset`, see `?@subset` for details.
 """
 macro where(x, args...)
-    @warn "`@where is deprecated, use `@subset`  with `@skipmissing` instead."
+    @warn "`@where is deprecated, use `@subset` instead."
     esc(where_helper(x, args...))
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -70,7 +70,7 @@ to indicate that the anonymous function created by DataFramesMeta
 to represent an operation should be applied "by-row".
 
 If an expression starts with `@byrow`, either of the form `@byrow :y = f(:x)`
-in transformations or `@byrow f(:x)` in `@orderby`, `@where`, and `@with`,
+in transformations or `@byrow f(:x)` in `@orderby`, `@subset`, and `@with`,
 then the anonymous function created by DataFramesMeta is wrapped in the
 `DataFrames.ByRow` function wrapper, which broadcasts the function so that it run on each row.
 
@@ -89,7 +89,7 @@ julia> @transform(df, @byrow :c = :a * :b)
    3 │     3      7     21
    4 │     4      8     32
 
-julia> @where(df, @byrow :a == 1 ? true : false)
+julia> @subset(df, @byrow :a == 1 ? true : false)
 1×2 DataFrame
  Row │ a      b
      │ Int64  Int64
@@ -102,7 +102,7 @@ operations, it is allowed to use`@byrow` at the beginning of a block of
 operations. All transformations in the block will operate by row.
 
 ```julia
-julia> @where df @byrow begin
+julia> @subset df @byrow begin
            :a > 1
            :b < 5
        end
@@ -578,7 +578,7 @@ macro subset(x, args...)
 end
 
 """
-    @where(x, args...)
+    @subset(x, args...)
 
 Deprecated version of `@subset`, see `?@subset` for details.
 """


### PR DESCRIPTION
which mentions an unexported `@skipmissing`, which never got implemented.

Judging from 

https://github.com/pdeffebach/DataFramesMeta.jl/blob/8d55422f7f95fd8008fc895b54dc457506a19352/src/macros.jl#L428

and

https://github.com/pdeffebach/DataFramesMeta.jl/blob/8d55422f7f95fd8008fc895b54dc457506a19352/src/macros.jl#L436

added in https://github.com/JuliaData/DataFramesMeta.jl/pull/263, the `skipmissing` kwarg is set to `true` already by default when calling `@subset` and `@subset!`. So `@subset` appears to be a drop-in replacement for `@where` without having to do extra work.

