### PR TITLE
Rename `@with` to `@withcols`

### DIFF
--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -9,7 +9,7 @@ using MacroTools
 @reexport using Chain
 
 # Basics:
-export @with,
+export @withcols,
        @subset, @subset!, @rsubset, @rsubset!,
        @orderby, @rorderby,
        @by, @combine,
@@ -17,7 +17,7 @@ export @with,
        @rtransform, @rselect, @rtransform!, @rselect!,
        @eachrow, @eachrow!,
        @byrow,
-       @based_on, @where # deprecated
+       @based_on, @where, @with # deprecated
 
 include("parsing.jl")
 include("macros.jl")

--- a/src/eachrow.jl
+++ b/src/eachrow.jl
@@ -88,7 +88,7 @@ end
 Includes support for control flow and `begin end` blocks. Since the
 "environment" induced by `@eachrow df` is implicitly a single row of `df`,
 use regular operators and comparisons instead of their elementwise counterparts
-as in `@with`. Note that the scope within `@eachrow` is a hard scope.
+as in `@withcols`. Note that the scope within `@eachrow` is a hard scope.
 
 `eachrow` also supports special syntax for allocating new columns. The syntax
 `@newcol x::Vector{Int}` allocates a new uninitialized column `:x` with an `Vector` container
@@ -230,7 +230,7 @@ end
 Includes support for control flow and `begin end` blocks. Since the
 "environment" induced by `@eachrow! df` is implicitly a single row of `df`,
 use regular operators and comparisons instead of their elementwise counterparts
-as in `@with`. Note that the scope within `@eachrow!` is a hard scope.
+as in `@withcols`. Note that the scope within `@eachrow!` is a hard scope.
 
 `eachrow!` also supports special syntax for allocating new columns. The syntax
 `@newcol x::Vector{Int}` allocates a new uninitialized column `:x` with an `Vector` container

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -12,7 +12,7 @@ DataFrames's `source => fun => destination` syntax.
 
 ### Details
 
-Parsing follows the same convention as other DataFramesMeta.jl macros, such as `@with`. All
+Parsing follows the same convention as other DataFramesMeta.jl macros, such as `@withcols`. All
 terms in the expression that are `Symbol`s are treated as columns in the data frame, except
 `Symbol`s wrapped in `^`. To use a variable representing a column name, wrap the variable
 in `\$`.
@@ -70,7 +70,7 @@ to indicate that the anonymous function created by DataFramesMeta
 to represent an operation should be applied "by-row".
 
 If an expression starts with `@byrow`, either of the form `@byrow :y = f(:x)`
-in transformations or `@byrow f(:x)` in `@orderby`, `@subset`, and `@with`,
+in transformations or `@byrow f(:x)` in `@orderby`, `@subset`, and `@withcols`,
 then the anonymous function created by DataFramesMeta is wrapped in the
 `DataFrames.ByRow` function wrapper, which broadcasts the function so that it run on each row.
 
@@ -144,7 +144,7 @@ Rather, `@eachrow` and `@eachrow!` return data frames.
 Now consider `@byrow`. `@byrow` transforms
 
 ```julia
-@with df @byrow begin
+@withcols df @byrow begin
     :a * :b
 end
 ```
@@ -156,7 +156,7 @@ tempfun(a, b) = a * b
 tempfun.(df.a, df.b)
 ```
 
-In contrast to `@eachrow`, `@with` combined with `@byrow` returns a vector of the
+In contrast to `@eachrow`, `@withcols` combined with `@byrow` returns a vector of the
 broadcasted multiplication and not a data frame.
 
 Additionally, transformations applied using `@eachrow!` modify the input
@@ -165,7 +165,7 @@ data frame. On the contrary, `@byrow` does not update columns.
 ```julia
 julia> df = DataFrame(a = [1, 2], b = [3, 4]);
 
-julia> @with df @byrow begin
+julia> @withcols df @byrow begin
            :a = 500
        end
 2-element Vector{Int64}:
@@ -198,7 +198,7 @@ df = DataFrame(a = [1, 2], b = [3, 4])
   is not possible in Julia versions below 1.7.
 
 ```
-julia> @with df @byrow begin
+julia> @withcols df @byrow begin
            if :a == 1
                5
            else
@@ -209,7 +209,7 @@ julia> @with df @byrow begin
   5
  10
 
-julia> @with df @. begin
+julia> @withcols df @. begin
            if :a == 1
                5
            else
@@ -225,7 +225,7 @@ julia> @with df @. begin
 
 ```julia
 julia> df = DataFrame(a = [1, 2], b = [3, 4]);
-julia> @with df @byrow :x + [5, 6]
+julia> @withcols df @byrow :x + [5, 6]
 ```
 
   will error, because the `:x` in the above expression refers
@@ -234,7 +234,7 @@ julia> @with df @byrow :x + [5, 6]
   On the other hand
 
 ```julia
-@with df @. :x + [5, 6]
+@withcols df @. :x + [5, 6]
 ```
 
   will succeed, as `df.x` is a 2-element vector as is `[5, 6]`.
@@ -257,10 +257,10 @@ julia> function expensive()
            return 1
        end;
 
-julia> @time @with df @byrow :a + expensive();
+julia> @time @withcols df @byrow :a + expensive();
   1.037073 seconds (51.67 k allocations: 3.035 MiB, 3.19% compilation time)
 
-julia> @time @with df :a .+ expensive();
+julia> @time @withcols df :a .+ expensive();
   0.539900 seconds (110.67 k allocations: 6.525 MiB, 7.05% compilation time)
 
 ```
@@ -269,10 +269,10 @@ julia> @time @with df :a .+ expensive();
   but can easily be fixed with `\$`.
 
 ```julia
-julia> @time @with df @. :a + expensive();
+julia> @time @withcols df @. :a + expensive();
   1.036888 seconds (97.55 k allocations: 5.617 MiB, 3.20% compilation time)
 
-julia> @time @with df @. :a + \$expensive();
+julia> @time @withcols df @. :a + \$expensive();
   0.537961 seconds (110.68 k allocations: 6.525 MiB, 6.73% compilation time)
 ```
 
@@ -352,7 +352,7 @@ end
 
 ##############################################################################
 ##
-## @with
+## @withcols
 ##
 ##############################################################################
 
@@ -367,7 +367,7 @@ getsinglecolumn(df, s::DataFrames.ColumnIndex) = df[!, s]
 getsinglecolumn(df, s) = throw(ArgumentError("Only indexing with Symbols, strings and integers " *
     "is currently allowed with \$"))
 
-function with_helper(d, body)
+function withcols_helper(d, body)
     # Make body an expression to force the
     # complicated method of fun_to_vec
     # in the case of QuoteNode
@@ -376,9 +376,9 @@ function with_helper(d, body)
 end
 
 """
-    @with(d, expr)
+    @withcols(d, expr)
 
-`@with` allows DataFrame columns keys to be referenced as symbols.
+`@withcols` allows DataFrame columns keys to be referenced as symbols.
 
 ### Arguments
 
@@ -387,7 +387,7 @@ end
 
 ### Details
 
-`@with` works by parsing the expression body for all columns indicated
+`@withcols` works by parsing the expression body for all columns indicated
 by symbols (e.g. `:colA`). Then, a function is created that wraps the
 body and passes the columns as function arguments. This function is
 then called. Operations are efficient because:
@@ -398,7 +398,7 @@ then called. Operations are efficient because:
 The following
 
 ```julia
-@with(d, :a .+ :b .+ 1)
+@withcols(d, :a .+ :b .+ 1)
 ```
 
 becomes
@@ -412,8 +412,8 @@ If an expression is wrapped in `^(expr)`, `expr` gets passed through untouched.
 If an expression is wrapped in  `\$(expr)`, the column is referenced by the
 variable `expr` rather than a symbol.
 
-If the expression provide to `@with` begins with `@byrow`, the function
-created by the `@with` block is broadcasted along the columns of the
+If the expression provide to `@withcols` begins with `@byrow`, the function
+created by the `@withcols` block is broadcasted along the columns of the
 data frame.
 
 ### Examples
@@ -427,19 +427,19 @@ julia> df = DataFrame(x = 1:3, y = [2, 1, 2]);
 
 julia> x = [2, 1, 0];
 
-julia> @with(df, :y .+ 1)
+julia> @withcols(df, :y .+ 1)
 3-element Array{Int64,1}:
  3
  2
  3
 
-julia> @with(df, :x + x)
+julia> @withcols(df, :x + x)
 3-element Array{Int64,1}:
  3
  3
  3
 
-julia> @with df begin
+julia> @withcols df begin
             res = 0.0
             for i in 1:length(:x)
                 res += :x[i] * :y[i]
@@ -448,20 +448,20 @@ julia> @with df begin
         end
 10.0
 
-julia> @with(df, df[:x .> 1, ^(:y)]) # The ^ means leave the :y alone
+julia> @withcols(df, df[:x .> 1, ^(:y)]) # The ^ means leave the :y alone
 2-element Array{Int64,1}:
  1
  2
 
 julia> colref = :x;
 
-julia> @with(df, :y + \$colref) # Equivalent to df[!, :y] + df[!, colref]
+julia> @withcols(df, :y + \$colref) # Equivalent to df[!, :y] + df[!, colref]
 3-element Array{Int64,1}:
  3
  3
  5
 
-julia> @with df @byrow :x * :y
+julia> @withcols df @byrow :x * :y
 3-element Vector{Int64}:
  2
  2
@@ -470,7 +470,7 @@ julia> @with df @byrow :x * :y
 ```
 
 !!! note
-    `@with` creates a function, so the scope within `@with` is a local scope.
+    `@withcols` creates a function, so the scope within `@withcols` is a local scope.
     Variables in the parent can be read. Writing to variables in the parent scope
     differs depending on the type of scope of the parent. If the parent scope is a
     global scope, then a variable cannot be assigned without using the `global` keyword.

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -227,7 +227,7 @@ function fun_to_vec(ex::Expr;
     # classify the type of expression
     # :x # handled via dispatch
     # $:x # handled as though above
-    # f(:x) # requires no_dest, for `@with` and `@subset` in future
+    # f(:x) # requires no_dest, for `@withcols` and `@subset`
     # :y = :x # Simple pair
     # :y = $:x # Extract and return simple pair (no function)
     # $:y = :x # Simple pair

--- a/test/byrow.jl
+++ b/test/byrow.jl
@@ -385,18 +385,18 @@ end
     @test d ≅ @select!(copy(df), :n1 = :i .* :g, :n2 = :i .* :g)
 end
 
-@testset "@with with @byrow" begin
+@testset "@withcols with @byrow" begin
     df = DataFrame(A = 1:3, B = [2, 1, 2])
 
-    @test @with(df, @byrow :A * 1)   ==  df.A .* 1
-    @test @with(df, @byrow :A * :B)  ==  df.A .* df.B
+    @test @withcols(df, @byrow :A * 1)   ==  df.A .* 1
+    @test @withcols(df, @byrow :A * :B)  ==  df.A .* df.B
 
-    t = @with df @byrow begin
+    t = @withcols df @byrow begin
         :A * 1
     end
     @test t == df.A .* 1
 
-    t = @with df @byrow begin
+    t = @withcols df @byrow begin
         :A * :B
     end
     @test t == df.A .* df.B

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -558,16 +558,16 @@ end
     @test_throws LoadError @eval @select(df; :n = :i)
 end
 
-@testset "with" begin
+@testset "withcols" begin
     df = DataFrame(A = 1:3, B = [2, 1, 2])
 
     x = [2, 1, 0]
 
-    @test  @with(df, :A .+ 1)   ==  df.A .+ 1
-    @test  @with(df, :A .+ :B)  ==  df.A .+ df.B
-    @test  @with(df, :A .+ x)   ==  df.A .+ x
+    @test  @withcols(df, :A .+ 1)   ==  df.A .+ 1
+    @test  @withcols(df, :A .+ :B)  ==  df.A .+ df.B
+    @test  @withcols(df, :A .+ x)   ==  df.A .+ x
 
-    x = @with df begin
+    x = @withcols df begin
         res = 0.0
         for i in 1:length(:A)
             res += :A[i] * :B[i]
@@ -575,20 +575,20 @@ end
         res
     end
     idx = :A
-    @test  @with(df, $idx .+ :B)  ==  df.A .+ df.B
+    @test  @withcols(df, $idx .+ :B)  ==  df.A .+ df.B
     idx2 = :B
-    @test  @with(df, $idx .+ $idx2)  ==  df.A .+ df.B
-    @test  @with(df, $:A .+ $"B")  ==  df.A .+ df.B
+    @test  @withcols(df, $idx .+ $idx2)  ==  df.A .+ df.B
+    @test  @withcols(df, $:A .+ $"B")  ==  df.A .+ df.B
 
-    @test_throws ArgumentError @with(df, :A + $2)
+    @test_throws ArgumentError @withcols(df, :A + $2)
 
     @test  x == sum(df.A .* df.B)
-    @test  @with(df, df[:A .> 1, ^([:B, :A])]) == df[df.A .> 1, [:B, :A]]
-    @test  @with(df, DataFrame(a = :A * 2, b = :A .+ :B)) == DataFrame(a = df.A * 2, b = df.A .+ df.B)
+    @test  @withcols(df, df[:A .> 1, ^([:B, :A])]) == df[df.A .> 1, [:B, :A]]
+    @test  @withcols(df, DataFrame(a = :A * 2, b = :A .+ :B)) == DataFrame(a = df.A * 2, b = df.A .+ df.B)
 
-    @test @with(df, :A) === df.A
-    @test @with(df, $:A) === df.A
-    @test @with(df, $"A") === df.A
+    @test @withcols(df, :A) === df.A
+    @test @withcols(df, $:A) === df.A
+    @test @withcols(df, $"A") === df.A
 end
 
 @testset "orderby" begin

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -201,4 +201,54 @@ end
     @test (@combine(gd, n = first(:i))) ≅ newdf
 end
 
+@testset "with" begin
+    df = DataFrame(A = 1:3, B = [2, 1, 2])
+
+    x = [2, 1, 0]
+
+    @test  @with(df, :A .+ 1)   ==  df.A .+ 1
+    @test  @with(df, :A .+ :B)  ==  df.A .+ df.B
+    @test  @with(df, :A .+ x)   ==  df.A .+ x
+
+    x = @with df begin
+        res = 0.0
+        for i in 1:length(:A)
+            res += :A[i] * :B[i]
+        end
+        res
+    end
+    idx = :A
+    @test  @with(df, $idx .+ :B)  ==  df.A .+ df.B
+    idx2 = :B
+    @test  @with(df, $idx .+ $idx2)  ==  df.A .+ df.B
+    @test  @with(df, $:A .+ $"B")  ==  df.A .+ df.B
+
+    @test_throws ArgumentError @with(df, :A + $2)
+
+    @test  x == sum(df.A .* df.B)
+    @test  @with(df, df[:A .> 1, ^([:B, :A])]) == df[df.A .> 1, [:B, :A]]
+    @test  @with(df, DataFrame(a = :A * 2, b = :A .+ :B)) == DataFrame(a = df.A * 2, b = df.A .+ df.B)
+
+    @test @with(df, :A) === df.A
+    @test @with(df, $:A) === df.A
+    @test @with(df, $"A") === df.A
+end
+
+@testset "@with with @byrow" begin
+    df = DataFrame(A = 1:3, B = [2, 1, 2])
+
+    @test @with(df, @byrow :A * 1)   ==  df.A .* 1
+    @test @with(df, @byrow :A * :B)  ==  df.A .* df.B
+
+    t = @with df @byrow begin
+        :A * 1
+    end
+    @test t == df.A .* 1
+
+    t = @with df @byrow begin
+        :A * :B
+    end
+    @test t == df.A .* df.B
+end
+
 end # module

--- a/test/function_compilation.jl
+++ b/test/function_compilation.jl
@@ -160,29 +160,29 @@ using DataFramesMeta
             slowtime = @timed combine(gd, :b => (b -> testnt(b)) => AsTable)
             (slowtime[2] > fasttime[2]) || @warn("Slow compilation")
 
-            @test @with df (:a + :b) == [3]
+            @test @withcols df (:a + :b) == [3]
 
-            fasttime = @timed @with df (:a + :b)
-            slowtime = @timed @with df ((a, b) -> a + b)(df.a, df.b)
+            fasttime = @timed @withcols df (:a + :b)
+            slowtime = @timed @withcols df ((a, b) -> a + b)(df.a, df.b)
             (slowtime[2] > fasttime[2]) || @warn("Slow compilation")
 
-            @test @with df (:a .* :b) == [2]
+            @test @withcols df (:a .* :b) == [2]
 
-            @with df (:a .* :b)
-            fasttime = @timed @with df (:a .* :b)
-            slowtime = @timed @with df ((a, b) -> a .* b)(df.a, df.b)
+            @withcols df (:a .* :b)
+            fasttime = @timed @withcols df (:a .* :b)
+            slowtime = @timed @withcols df ((a, b) -> a .* b)(df.a, df.b)
             (slowtime[2] > fasttime[2]) || @warn("Slow compilation")
 
-            @test @with df testfun(:a, :b) == [2]
+            @test @withcols df testfun(:a, :b) == [2]
 
-            fasttime = @timed @with df testfun(:a, :b)
-            slowtime = @timed @with df ((a, b) -> testfun(a, b))(df.a, df.b)
+            fasttime = @timed @withcols df testfun(:a, :b)
+            slowtime = @timed @withcols df ((a, b) -> testfun(a, b))(df.a, df.b)
             (slowtime[2] > fasttime[2]) || @warn("Slow compilation")
 
-            @test @with df testdotfun.(:a, :b) == [2]
+            @test @withcols df testdotfun.(:a, :b) == [2]
 
-            fasttime = @timed @with df testdotfun.(:a, :b)
-            slowtime = @timed @with df ((a, b) -> testdotfun.(a, b))(df.a, df.b)
+            fasttime = @timed @withcols df testdotfun.(:a, :b)
+            slowtime = @timed @withcols df ((a, b) -> testdotfun.(a, b))(df.a, df.b)
             (slowtime[2] > fasttime[2]) || @warn("Slow compilation")
         end
     end


### PR DESCRIPTION
Resolves #252 . 

The main motivation for this change is [StaticModules.jl](https://github.com/MasonProtter/StaticModules.jl) which exports the `@with` macro which has a more intuitive functionality than our `@with`. It simply replaces references to fields within `x` to `x.`. 

If this package, or similar ones, take off, then `DataFramesMeta.@with` will be both less general and inferior, since we will still require `:x` instead of `x` everywhere. You won't be able to use `StaticModules.@with` with DataFrames because the type instability of columns. 

cc @masonprotter @bkamins  and for good measure @jkrumbiegel  

