### PR TITLE
Prepare for 0.9.0 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFramesMeta"
 uuid = "1313f7d8-7da2-5740-9ea0-a2ca25f37964"
-version = "0.8.0"
+version = "0.9.0"
 
 [deps]
 Chain = "8be319e6-bccf-4806-a6f7-6fae938471bc"
@@ -9,7 +9,7 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-DataFrames = "0.22, 1"
+DataFrames = "1"
 MacroTools = "0.5"
 Reexport = "0.2, 1"
 julia = "1"

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -16,7 +16,7 @@ export @with,
        @transform, @select, @transform!, @select!,
        @rtransform, @rselect, @rtransform!, @rselect!,
        @eachrow, @eachrow!,
-       @byrow,
+       @byrow, @passmissing,
        @based_on, @where # deprecated
 
 include("parsing.jl")


### PR DESCRIPTION
This PR does 3 things

1. exports `@passmissing` for users to use the documentation, `? @passmissing` will work even if `@passmissing ...` won't outside of DataFramesMeta.jl macros
2. Only allows for DataFrames > 1.0, to fix #274 
3. Bump version to 0.9.0

We need to bump the version because we add new features and are pre-1.0. 

