### PR TITLE
Fix escaping `$`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -401,9 +401,9 @@ julia> @rtransform df @passmissing x = parse(Int, :x_str)
 
 
 
-## Working with column names programmatically with `\$`
+## Working with column names programmatically with `$`
 
-DataFramesMeta provides the special syntax `\$` for referring to 
+DataFramesMeta provides the special syntax `$` for referring to 
 columns in a data frame via a `Symbol`, string, or column position as either
 a literal or a variable. 
 
@@ -422,7 +422,7 @@ df4 = @eachrow df begin
 end
 ```
 
-`\$` can also be used to create new columns in a data frame. 
+`$` can also be used to create new columns in a data frame. 
 
 ```julia
 df = DataFrame(A = 1:3, B = [2, 1, 2])

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -19,6 +19,8 @@ export @with,
        @byrow,
        @based_on, @where # deprecated
 
+const DOLLAR = raw"$"
+
 include("parsing.jl")
 include("macros.jl")
 include("linqmacro.jl")

--- a/src/eachrow.jl
+++ b/src/eachrow.jl
@@ -102,8 +102,8 @@ by `@eachrow`. Also note that the returned data frame does not share columns
 with `df`. See [`@eachrow!`](@ref) which employs the same syntax but modifies
 the data frame in-place.
 
-Like with `@transform`, `@eachrow` supports the use of `\$` to work with column names
-stored as variables. Using `\$` with a multi-column selector, such as a `Vector` of
+Like with `@transform`, `@eachrow` supports the use of `$DOLLAR` to work with column names
+stored as variables. Using `$DOLLAR` with a multi-column selector, such as a `Vector` of
 `Symbol`s, is currently unsupported.
 
 ### Arguments
@@ -161,7 +161,7 @@ julia> varA = :A; varB = :B;
 
 julia> df2 = @eachrow df begin
            @newcol :colX::Vector{Float64}
-           :colX = \$varB == 2 ? pi * \$varA : \$varB
+           :colX = $(DOLLAR)varB == 2 ? pi * $(DOLLAR)varA : $(DOLLAR)varB
        end
 3×3 DataFrame
  Row │ A      B      colX
@@ -243,8 +243,8 @@ Changes to the rows directly affect `df`. The operation will modify the
 data frame in place. See [`@eachrow`](@ref) which employs the same syntax but allocates
 a fresh data frame.
 
-Like with `@transform!`, `@eachrow!` supports the use of `\$` to work with column names
-stored as variables. Using `\$` with a multi-column selector, such as a `Vector` of
+Like with `@transform!`, `@eachrow!` supports the use of `$DOLLAR` to work with column names
+stored as variables. Using `$DOLLAR` with a multi-column selector, such as a `Vector` of
 `Symbol`s, is currently unsupported.
 
 ### Arguments
@@ -310,7 +310,7 @@ julia> df2 = copy(df);
 
 julia> @eachrow! df2 begin
            @newcol :colX::Vector{Float64}
-           :colX = \$varB == 2 ? pi * \$varA : \$varB
+           :colX = $(DOLLAR)varB == 2 ? pi * $(DOLLAR)varA : $(DOLLAR)varB
        end
 3×3 DataFrame
  Row │ A      B      colX

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -15,7 +15,7 @@ DataFrames's `source => fun => destination` syntax.
 Parsing follows the same convention as other DataFramesMeta.jl macros, such as `@with`. All
 terms in the expression that are `Symbol`s are treated as columns in the data frame, except
 `Symbol`s wrapped in `^`. To use a variable representing a column name, wrap the variable
-in `\$`.
+in `$DOLLAR`.
 
 `@col` constructs an anonymous function `fun` based on the given expression. It then creates
 a `source => fun => destination` pair that is suitable for the `select`, `transform`, and
@@ -98,7 +98,7 @@ julia> @subset(df, @byrow :a == 1 ? true : false)
 ```
 
 To avoid writing `@byrow` multiple times when performing multiple
-operations, it is allowed to use`@byrow` at the beginning of a block of
+operations, it is allowed to use `@byrow` at the beginning of a block of
 operations. All transformations in the block will operate by row.
 
 ```julia
@@ -266,17 +266,17 @@ julia> @time @with df :a .+ expensive();
 ```
 
   This problem comes up when using the `@.` macro as well,
-  but can easily be fixed with `\$`.
+  but can easily be fixed with `$DOLLAR`. Because $DOLLAR is currently
+  reserved for escaping column references, no solution currently exists with
+  `@byrow` or in DataFramesMeta.jl at large. The best solution is simply
 
-```julia
-julia> @time @with df @. :a + expensive();
-  1.036888 seconds (97.55 k allocations: 5.617 MiB, 3.20% compilation time)
-
-julia> @time @with df @. :a + \$expensive();
-  0.537961 seconds (110.68 k allocations: 6.525 MiB, 6.73% compilation time)
+```
+@with df begin
+    x = expensive()
+    :a + x
+end
 ```
 
-  No such solution currently exists with `@byrow`.
 """
 macro byrow(args...)
     throw(ArgumentError("@byrow is deprecated outside of DataFramesMeta macros."))
@@ -365,7 +365,7 @@ exec(df, s::Union{Symbol, AbstractString}) = df[!, s]
 
 getsinglecolumn(df, s::DataFrames.ColumnIndex) = df[!, s]
 getsinglecolumn(df, s) = throw(ArgumentError("Only indexing with Symbols, strings and integers " *
-    "is currently allowed with \$"))
+    "is currently allowed with $DOLLAR"))
 
 function with_helper(d, body)
     # Make body an expression to force the
@@ -409,7 +409,7 @@ tempfun(d[!, :a], d[!, :b])
 ```
 
 If an expression is wrapped in `^(expr)`, `expr` gets passed through untouched.
-If an expression is wrapped in  `\$(expr)`, the column is referenced by the
+If an expression is wrapped in  `$DOLLAR(expr)`, the column is referenced by the
 variable `expr` rather than a symbol.
 
 If the expression provide to `@with` begins with `@byrow`, the function
@@ -455,7 +455,7 @@ julia> @with(df, df[:x .> 1, ^(:y)]) # The ^ means leave the :y alone
 
 julia> colref = :x;
 
-julia> @with(df, :y + \$colref) # Equivalent to df[!, :y] + df[!, colref]
+julia> @with(df, :y + $(DOLLAR)colref) # Equivalent to df[!, :y] + df[!, colref]
 3-element Vector{Int64}:
  3
  3
@@ -1550,7 +1550,7 @@ function combine_helper(x, args...; deprecation_warning = false)
         !(fe isa QuoteNode || onearg(fe, :cols) || is_column_expr(fe)) &&
         !(fe.head == :(=) || fe.head == :kw)
 
-        @warn "Returning a Table object from @by and @combine now requires `\$AsTable` on the LHS."
+        @warn "Returning a Table object from @by and @combine now requires `$DOLLARAsTable` on the LHS."
 
         lhs = Expr(:$, :AsTable)
         exprs = ((:($lhs = $fe)),)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -266,7 +266,7 @@ julia> @time @with df :a .+ expensive();
 ```
 
   This problem comes up when using the `@.` macro as well,
-  but can easily be fixed with `$DOLLAR`. Because $DOLLAR is currently
+  but can easily be fixed with `$DOLLAR`. Because `$DOLLAR` is currently
   reserved for escaping column references, no solution currently exists with
   `@byrow` or in DataFramesMeta.jl at large. The best solution is simply
 
@@ -1550,7 +1550,7 @@ function combine_helper(x, args...; deprecation_warning = false)
         !(fe isa QuoteNode || onearg(fe, :cols) || is_column_expr(fe)) &&
         !(fe.head == :(=) || fe.head == :kw)
 
-        @warn "Returning a Table object from @by and @combine now requires `$DOLLARAsTable` on the LHS."
+        @warn "Returning a Table object from @by and @combine now requires `$(DOLLAR)AsTable` on the LHS."
 
         lhs = Expr(:$, :AsTable)
         exprs = ((:($lhs = $fe)),)


### PR DESCRIPTION
Rules: 

Inside `.md` files, you can use `$` however much you want. 

Inside docstrings, we have the global variable `const DOLLAR = raw"$"`. We interpolate `$DOLLAR` everywhere we want a raw `$`, which is ironic. 