### PR TITLE
Allow AsTable on RHS in transformations

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -525,15 +525,15 @@ To reference columns with more complicated expressions, you must wrap column ref
 @transform df :a + $(get_column_name(x))
 ```
 
-### Operations with multiple columns at once using `AsTable` inside operations
+## Operations with multiple columns at once using `AsTable` inside operations
 
 In operations, it is also allowed to use `AsTable(cols)` to work with
 multiple columns at once, where the columns are grouped together in a
 `NamedTuple`. When `AsTable(cols)` appears in a operation, no
 other columns may be referenced in the block.
 
-`AsTable` on the right-hand-side also allows the use of the special
-column selectors `Not`, `Between`, and regular expressions. As well
+`AsTable` on the right-hand side also allows the use of the special
+column selectors `Not`, `Between`, and regular expressions, as well
 as working with lists of variables programmatically. 
 
 For example, consider a collection of column names `vars`, such that
@@ -596,7 +596,9 @@ inside the expression. The command
 
 will fail. 
 
-Finally, note that everyting inside `AsTable` is escaped by default. There is no ned to use `$` inside `AsTable` on the right-hand-side. For example
+Finally, note that everyting inside `AsTable` is escaped by default.
+There is no ned to use `$` inside `AsTable` on the right-hand side.
+For example
 
 ```
 :y = first(AsTable("a"))
@@ -609,15 +611,15 @@ will work as expected.
 
 At this point we have seen `AsTable` appear in three places:
 
-1. `AsTable` on the left-hand-side of transformations: `$AsTable = f(:a, :b)`
+1. `AsTable` on the left-hand side of transformations: `$AsTable = f(:a, :b)`
 2. The macro-flag `@astable` within the transformation. 
-3. `AsTable(cols)` on the right hand side for multi-column transformations. 
+3. `AsTable(cols)` on the right-hand side for multi-column transformations. 
 
 The differences between the three is summarized below
 
 | Operation         | Purpose                                                                             | Example           | Notes |
 |-------------------|-------------------------------------------------------------------------------------|-------------------|-------|
-| `$AsTable` on LHS | Create multiple columns at once, whose column names are only known programmatically | <pre lang=julia>$AsTable = f(:y)</pre> | Requires escaping with `$` until deprecation period ends for unquoted column names on LHS.      |
+| `$AsTable` on LHS | Create multiple columns at once, whose column names are only known programmatically | <pre lang="julia">$AsTable = f(:y)</pre> | Requires escaping with `$` until deprecation period ends for unquoted column names on LHS.      |
 | `@astable`        | Create multiple columns at once where number of columns is known in advance         | <pre lang="julia">@astable begin<br>    :y = :x - 1<br>    :z =  :y - 1<br>end</pre>
 | `AsTable` on RHS  | Work with multiple columns at once                                                  |<pre lang="julia">:y = sum(AsTable(Between("a", "z")))</pre> | Requires input columns, unlike on LHS |
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -638,7 +638,7 @@ For example
 will work as expected.  
 
 
-### AsTable and `@astable`, explained
+## AsTable and `@astable`, explained
 
 At this point we have seen `AsTable` appear in three places:
 
@@ -648,14 +648,13 @@ At this point we have seen `AsTable` appear in three places:
 
 The differences between the three is summarized below
 
-| Operation         | Purpose                                                                             | Example           | Notes |
-|-------------------|-------------------------------------------------------------------------------------|-------------------|-------|
-| `$AsTable` on LHS | Create multiple columns at once, whose column names are only known programmatically | <pre lang="julia">$AsTable = f(:y)</pre> | Requires escaping with `$` until deprecation period ends for unquoted column names on LHS.      |
-| `@astable`        | Create multiple columns at once where number of columns is known in advance         | <pre lang="julia">@astable begin<br>    :y = :x - 1<br>    :z =  :y - 1<br>end</pre>
-| `AsTable` on RHS  | Work with multiple columns at once                                                  |<pre lang="julia">:y = sum(AsTable(Between("a", "z")))</pre> | Requires input columns, unlike on LHS |
+| Operation         | Purpose                                                                             | Notes |
+|-------------------|-------------------------------------------------------------------------------------|-------|
+| `$AsTable` on LHS | Create multiple columns at once, whose column names are only known programmatically |  Requires escaping with `$` until deprecation period ends for unquoted column names on LHS. |
+| `@astable`        | Create multiple columns at once where number of columns is known in advance         | |
+| `AsTable` on RHS  | Work with multiple columns at once                                                  | Requires input columns, unlike on LHS |
 
-
-### Using `src => fun => dest` calls using `$`
+## Using `src => fun => dest` calls using `$`
 
 If an argument is entirely wrapped in `$()`, the result bypasses the anonymous function 
 creation of DataFramesMeta.jl and is passed to the underling DataFrames.jl function 
@@ -680,10 +679,9 @@ julia> @transform df $([:a, :b] .=> [sum mean])
 ─────┼──────────────────────────────────────────────
    1 │     1     30      3     70      1.5     35.0
    2 │     2     40      3     70      1.5     35.0
-
 ```
 
-### Multi-argument column selection 
+## Multi-argument column selection 
 
 To refer to multiple columns in DataFrames.jl, one can write
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -572,9 +572,9 @@ julia> @rtransform df :y = sum(AsTable([:a, :b]))
 ```
 julia> function fun_with_new_name(x::NamedTuple)
            nms = string.(propertynames(x))
-           new_name = join(nms, "_") * "_sum"
+           new_name = Symbol(join(nms, "_"), "_sum")
            s = sum(x)
-           (; Symbol(new_name) => s)
+           (; new_name => s)
        end
 
 julia> @rtransform df $AsTable = fun_with_new_name(AsTable([:a, :b]))
@@ -659,13 +659,13 @@ The differences between the three is summarized below
 If an argument is entirely wrapped in `$()`, the result bypasses the anonymous function 
 creation of DataFramesMeta.jl and is passed to the underling DataFrames.jl function 
 directly. Importantly, this allows for `src => fun => dest` calls from the DataFrames.jl 
-"mini-language" directly. One example where this is useful is calling multiple functions across multiple input parameters. For insteance, the `Pair`
+"mini-language" directly. One example where this is useful is calling multiple functions across multiple input parameters. For instance, the `Pair`
 
 ```
 [:a, :b] .=> [sum mean]
 ```
 
-takes the `sum` and `mean` of both columns `:a` and `:b` separately. It is not possible to express this with DataFrames.jl. But the operation can easily be performed with `$`
+takes the `sum` and `mean` of both columns `:a` and `:b` separately. It is not possible to express this with DataFramesMeta.jl. But the operation can easily be performed with `$`
 
 ```
 julia> using Statistics

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -594,7 +594,33 @@ inside the expression. The command
 :y = sum(AsTable(cols)) + :d
 ```
 
-will fail.
+will fail. 
+
+Finally, note that everyting inside `AsTable` is escaped by default. There is no ned to use `$` inside `AsTable` on the right-hand-side. For example
+
+```
+:y = first(AsTable("a"))
+```
+
+will work as expected.  
+
+
+### AsTable and `@astable`, explained
+
+At this point we have seen `AsTable` appear in three places:
+
+1. `AsTable` on the left-hand-side of transformations: `$AsTable = f(:a, :b)`
+2. The macro-flag `@astable` within the transformation. 
+3. `AsTable(cols)` on the right hand side for multi-column transformations. 
+
+The differences between the three is summarized below
+
+| Operation         | Purpose                                                                             | Example           | Notes |
+|-------------------|-------------------------------------------------------------------------------------|-------------------|-------|
+| `$AsTable` on LHS | Create multiple columns at once, whose column names are only known programmatically | <pre lang=julia>$AsTable = f(:y)</pre> | Requires escaping with `$` until deprecation period ends for unquoted column names on LHS.      |
+| `@astable`        | Create multiple columns at once where number of columns is known in advance         | <pre lang="julia">@astable begin<br>    :y = :x - 1<br>    :z =  :y - 1<br>end</pre>
+| `AsTable` on RHS  | Work with multiple columns at once                                                  |<pre lang="julia">:y = sum(AsTable(Between("a", "z")))</pre> | Requires input columns, unlike on LHS |
+
 
 ### Using `src => fun => dest` calls using `$`
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -650,12 +650,12 @@ sum of the columns `:a`, `:b`, and `:c`, write
 This constructs the pair
 
 ```
-AsTable(nms) => ByRow(sum)
+AsTable(AsTable([:a, :b, :c])) => ByRow(sum)
 ```
 
-`AsTable` on the right-hand-side also allows the use of the special
+`AsTable` on the right-hand side also allows the use of the special
 column selectors `Not`, `Between`, and regular expressions. For example,
-order all rows by the product of all columns starting with `"a"`, write
+to order all rows by the product of all columns starting with `"a"`, write
 
 ```
 @byrow prod(AsTable(r"^a"))
@@ -679,12 +679,12 @@ sum of the columns `:a`, `:b`, and `:c` is greater than `5`, write
 This constructs the pair
 
 ```
-AsTable(nms) => ByRow(t -> sum(t) > 5)
+AsTable([:a, :b, :c]) => ByRow(t -> sum(t) > 5)
 ```
 
-`AsTable` on the right-hand-side also allows the use of the special
+`AsTable` on the right-hand side also allows the use of the special
 column selectors `Not`, `Between`, and regular expressions. For example,
-subset all rows where the product of all columns starting with `"a"`,
+to subset all rows where the product of all columns starting with `"a"`,
 is greater than `5`, write
 
 ```
@@ -712,7 +712,7 @@ This constructs the pairs
 AsTable(nms) => ByRow(sum) => :c
 ```
 
-`AsTable` on the right-hand-side also allows the use of the special
+`AsTable` on the right-hand side also allows the use of the special
 column selectors `Not`, `Between`, and regular expressions. For example,
 to calculate the product of all the columns beginning with the letter `"a"`,
 write

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -632,9 +632,9 @@ end
 
 # TODO: New docstring for @subset
 astable_rhs_docs = """
-In transformations, it is also allowed to use `AsTable(cols)` to work with
+In operations, it is also allowed to use `AsTable(cols)` to work with
 multiple columns at once, where the columns are grouped together in a
-`NamedTuple`. When `AsTable(cols)` appears in a transformation, no
+`NamedTuple`. When `AsTable(cols)` appears in a operation, no
 other columns may be referenced in the block.
 
 Using `AsTable` in this way is useful for working with many columns
@@ -661,7 +661,13 @@ write
 @byrow :d = prod(AsTable(r"^a"))
 ```
 
+`AsTable` inside operations can also be used in operations that do not
+create new columns, such as `@subset` and `@orderby`. For example, to
+order rows by the sum of all the columns beginning with `a`, write
 
+```
+@rorderby sum(AsTable(r"^a))
+```
 """
 
 ##############################################################################

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -349,7 +349,7 @@ macro passmissing(args...)
     throw(ArgumentError("@passmissing only works inside DataFramesMeta macros."))
 end
 
-const astable_docstring_snippet = """
+const astable_macro_flag_docs = """
     Transformations can also use the macro-flag [`@astable`](@ref) for creating multiple
     new columns at once and letting transformations share the same name-space.
     See `? @astable` for more details.
@@ -630,7 +630,8 @@ macro with(d, body)
     esc(with_helper(d, body))
 end
 
-AsTable_RHS_DOCSTRING = """
+# TODO: New docstring for @subset
+astable_rhs_docs = """
 In transformations, it is also allowed to use `AsTable(cols)` to work with
 multiple columns at once, where the columns are grouped together in a
 `NamedTuple`. When `AsTable(cols)` appears in a transformation, no
@@ -1278,7 +1279,9 @@ transformations by row, `@transform` allows `@byrow` at the
 beginning of a block of transformations (i.e. `@byrow begin... end`).
 All transformations in the block will operate by row.
 
-$astable_docstring_snippet
+$astable_macro_flag_docs
+
+$astable_rhs_docs
 
 ### Examples
 
@@ -1416,7 +1419,9 @@ transform!ations by row, `@transform!` allows `@byrow` at the
 beginning of a block of transform!ations (i.e. `@byrow begin... end`).
 All transform!ations in the block will operate by row.
 
-$astable_docstring_snippet
+$astable_macro_flag_docs
+
+$astable_rhs_docs
 
 ### Examples
 
@@ -1530,7 +1535,9 @@ transformations by row, `@select` allows `@byrow` at the
 beginning of a block of selectations (i.e. `@byrow begin... end`).
 All transformations in the block will operate by row.
 
-$astable_docstring_snippet
+$astable_macro_flag_docs
+
+$astable_rhs_docs
 
 ### Examples
 
@@ -1652,7 +1659,9 @@ transformations by row, `@select!` allows `@byrow` at the
 beginning of a block of select!ations (i.e. `@byrow begin... end`).
 All transformations in the block will operate by row.
 
-$astable_docstring_snippet
+$astable_macro_flag_docs
+
+$astable_rhs_docs
 
 ### Examples
 
@@ -1770,7 +1779,9 @@ and
 @combine(df, :mx = mean(:x), :sx = std(:x))
 ```
 
-$astable_docstring_snippet
+$astable_macro_flag_docs
+
+$astable_rhs_docs
 
 ### Examples
 
@@ -1888,7 +1899,9 @@ and
 @by(df, :g, mx = mean(:x), sx = std(:x))
 ```
 
-$astable_docstring_snippet
+$astable_macro_flag_docs
+
+$astable_rhs_docs
 
 ### Examples
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -349,7 +349,7 @@ macro passmissing(args...)
     throw(ArgumentError("@passmissing only works inside DataFramesMeta macros."))
 end
 
-const astable_macro_flag_docs = """
+const ASTABLE_MACRO_FLAG_DOCS = """
     Transformations can also use the macro-flag [`@astable`](@ref) for creating multiple
     new columns at once and letting transformations share the same name-space.
     See `? @astable` for more details.
@@ -633,7 +633,7 @@ macro with(d, body)
     esc(with_helper(d, body))
 end
 
-astable_rhs_orderby_docs = """
+ASTABLE_RHS_ORDERBY_DOCS = """
 In operations, it is also allowed to use `AsTable(cols)` to work with
 multiple columns at once, where the columns are grouped together in a
 `NamedTuple`. When `AsTable(cols)` appears in a operation, no
@@ -650,7 +650,7 @@ sum of the columns `:a`, `:b`, and `:c`, write
 This constructs the pair
 
 ```
-AsTable(AsTable([:a, :b, :c])) => ByRow(sum)
+AsTable([:a, :b, :c]) => ByRow(sum)
 ```
 
 `AsTable` on the right-hand side also allows the use of the special
@@ -662,7 +662,7 @@ to order all rows by the product of all columns starting with `"a"`, write
 ```
 """
 
-astable_rhs_subset_docs = """
+ASTABLE_RHS_SUBSET_DOCS = """
 In operations, it is also allowed to use `AsTable(cols)` to work with
 multiple columns at once, where the columns are grouped together in a
 `NamedTuple`. When `AsTable(cols)` appears in a operation, no
@@ -692,7 +692,7 @@ is greater than `5`, write
 ```
 """
 
-astable_rhs_select_transform_docs = """
+ASTABLE_RHS_SELECT_TRANSFORM_DOCS = """
 In operations, it is also allowed to use `AsTable(cols)` to work with
 multiple columns at once, where the columns are grouped together in a
 `NamedTuple`. When `AsTable(cols)` appears in a operation, no
@@ -803,7 +803,7 @@ and
 end
 ```
 
-$astable_rhs_subset_docs
+$ASTABLE_RHS_SUBSET_DOCS
 
 ### Examples
 
@@ -993,7 +993,7 @@ and
 end
 ```
 
-$astable_rhs_subset_docs
+$ASTABLE_RHS_SUBSET_DOCS
 
 ### Examples
 
@@ -1171,7 +1171,7 @@ and
 end
 ```
 
-$astable_rhs_orderby_docs
+$ASTABLE_RHS_ORDERBY_DOCS
 
 ### Examples
 
@@ -1342,9 +1342,9 @@ transformations by row, `@transform` allows `@byrow` at the
 beginning of a block of transformations (i.e. `@byrow begin... end`).
 All transformations in the block will operate by row.
 
-$astable_macro_flag_docs
+$ASTABLE_MACRO_FLAG_DOCS
 
-$astable_rhs_select_transform_docs
+$ASTABLE_RHS_SELECT_TRANSFORM_DOCS
 
 ### Examples
 
@@ -1482,9 +1482,9 @@ transform!ations by row, `@transform!` allows `@byrow` at the
 beginning of a block of transform!ations (i.e. `@byrow begin... end`).
 All transform!ations in the block will operate by row.
 
-$astable_macro_flag_docs
+$ASTABLE_MACRO_FLAG_DOCS
 
-$astable_rhs_select_transform_docs
+$ASTABLE_RHS_SELECT_TRANSFORM_DOCS
 
 ### Examples
 
@@ -1598,9 +1598,9 @@ transformations by row, `@select` allows `@byrow` at the
 beginning of a block of selectations (i.e. `@byrow begin... end`).
 All transformations in the block will operate by row.
 
-$astable_macro_flag_docs
+$ASTABLE_MACRO_FLAG_DOCS
 
-$astable_rhs_select_transform_docs
+$ASTABLE_RHS_SELECT_TRANSFORM_DOCS
 
 ### Examples
 
@@ -1722,9 +1722,9 @@ transformations by row, `@select!` allows `@byrow` at the
 beginning of a block of select!ations (i.e. `@byrow begin... end`).
 All transformations in the block will operate by row.
 
-$astable_macro_flag_docs
+$ASTABLE_MACRO_FLAG_DOCS
 
-$astable_rhs_select_transform_docs
+$ASTABLE_RHS_SELECT_TRANSFORM_DOCS
 
 ### Examples
 
@@ -1842,7 +1842,7 @@ and
 @combine(df, :mx = mean(:x), :sx = std(:x))
 ```
 
-$astable_macro_flag_docs
+$ASTABLE_MACRO_FLAG_DOCS
 
 ### Examples
 
@@ -1960,7 +1960,7 @@ and
 @by(df, :g, mx = mean(:x), sx = std(:x))
 ```
 
-$astable_macro_flag_docs
+$ASTABLE_MACRO_FLAG_DOCS
 
 ### Examples
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -630,6 +630,38 @@ macro with(d, body)
     esc(with_helper(d, body))
 end
 
+AsTable_RHS_DOCSTRING = """
+In transformations, it is also allowed to use `AsTable(cols)` to work with
+multiple columns at once, where the columns are grouped together in a
+`NamedTuple`. When `AsTable(cols)` appears in a transformation, no
+other columns may be referenced in the block.
+
+Using `AsTable` in this way is useful for working with many columns
+at once programatically. For example, to take a row-wise sum of the
+columns `[:a, :b, :c, :d]`, write
+
+```
+nms = [:a, :b, :c, :d]
+@byrow :c = sum(AsTable(nms))
+```
+
+The constructs the pair
+
+```
+AsTable(nms) => ByRow(sum) => :c
+```
+
+`AsTable` on the right-hand-side also allows the use of the special
+column selectors `Not`, `Between`, and regular expressions. For exampe,
+to calculate the product of all the columns beginning with the letter `"a"`,
+write
+
+```
+@byrow :d = prod(AsTable(r"^a"))
+```
+
+
+"""
 
 ##############################################################################
 ##

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -21,6 +21,7 @@ returns `nothing`.
 get_column_expr(x) = nothing
 function get_column_expr(e::Expr)
     e.head == :$ && return e.args[1]
+    onearg(e, :AsTable) && return e
     if onearg(e, :cols)
         Base.depwarn("cols is deprecated use $DOLLAR to escape column names instead", :cols)
         return e.args[2]
@@ -332,7 +333,9 @@ fun_to_vec(ex::QuoteNode;
            outer_flags::Union{NamedTuple, Nothing}=nothing) = ex
 
 function make_source_concrete(x::AbstractVector)
-    if isempty(x) || isconcretetype(eltype(x))
+    if length(x) == 1 && x[1] isa AsTable
+        return x[1]
+    elseif isempty(x) || isconcretetype(eltype(x))
         return x
     elseif all(t -> t isa Union{AbstractString, Symbol}, x)
         return Symbol.(x)

--- a/test/astable_rhs.jl
+++ b/test/astable_rhs.jl
@@ -1,0 +1,37 @@
+module Testbyrow
+
+using Test
+using DataFrames
+using DataFramesMeta
+using Statistics
+
+const ≅ = isequal
+
+
+@testset "AsTable on RHS" begin
+    df = DataFrame(a = [1, 2], b = [3, 4], d = [100, 200])
+
+    res = DataFrame(a = [1, 2], b = [3, 4], d = [100, 200], c = [4, 6])
+
+    d = @transform df :c = sum(AsTable([:a, :b]))
+    @test d == res
+
+    d = @rtransform df :c = sum(AsTable([:a, :b]))
+    @test d == res
+
+    d = @transform df @byrow :c = sum(AsTable([:a, :b]))
+    @test d == res
+
+    vars = ["a", "b"]
+
+    d = @rtransform df :c = sum(AsTable(vars))
+    @test d == res
+
+    d = @rtransform df :c = sum(AsTable(Between(:a, :b)))
+    @test d == res
+
+    d = @transform df :c = sum(AsTable(Not(:d)))
+    @test d == res
+end
+
+end # module


### PR DESCRIPTION
After the recent improvements to `AsTable` in DataFrames, I guess it's time to make it easier to work with this construct in DataFramesMeta.jl. 

No tests added yet. 