### PR TITLE
Small docstring fix in src/macros.jl

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -694,7 +694,7 @@ and
 
 If an expression provided to `@subset` begins with `@byrow`, operations
 are applied "by row" along the data frame. To avoid writing `@byrow` multiple
-times, `@orderby` also allows `@byrow`to be placed at the beginning of a block of
+times, `@orderby` also allows `@byrow` to be placed at the beginning of a block of
 operations. For example, the following two statements are equivalent.
 
 ```


### PR DESCRIPTION
I was seeing the help for `@subset` in a Julia REPL and noticed that there is a missing space in the docstring.