### PR TITLE
Composition of nested functions

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -97,18 +97,16 @@ make_composed(x) = x
 function make_composed(x::Expr)
     funs = Any[]
     x_orig = x
+    nested_once = false
     while true
         if is_nested_fun(x)
             push!(funs, x.args[1])
             x = x.args[2]
-        elseif is_simple_non_broadcast_call(x)
-            if !isempty(funs)
+            nested_once = true
+        elseif is_simple_non_broadcast_call(x) && nested_once
                 push!(funs, x.args[1])
                 # ∘(f, g, h)(:x, :y, :z)
                 return Expr(:call, Expr(:call, ∘, funs...), x.args[2:end]...)
-            else
-                throw(Argumenterror("Not eligible for function composition"))
-            end
         else
             throw(Argumenterror("Not eligible for function composition"))
         end

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -68,15 +68,15 @@ function composed_or_symbol(x::Expr)
 end
 
 is_call(x) = false
-is_call(x::Expr) = x.head == :call
+is_call(x::Expr) = x.head === :call
 
 is_nested_fun(x) = false
 function is_nested_fun(x::Expr)
-    x.head == :call &&
+    x.head === :call &&
     length(x.args) == 2 &&
     is_call(x.args[2]) &&
     # AsTable(:x) or `$(:x)`
-    get_column_expr(x.args[2]) == nothing
+    return get_column_expr(x.args[2]) === nothing
 end
 
 is_nested_fun_recursive(x, nested_once) = false
@@ -84,11 +84,7 @@ function is_nested_fun_recursive(x::Expr, nested_once)
     if is_nested_fun(x)
         return is_nested_fun_recursive(x.args[2], true)
     elseif is_simple_non_broadcast_call(x)
-        if nested_once
-            return true
-        else
-            return false
-        end
+        return nested_once
     else
         return false
     end
@@ -104,11 +100,11 @@ function make_composed(x::Expr)
             x = x.args[2]
             nested_once = true
         elseif is_simple_non_broadcast_call(x) && nested_once
-                push!(funs, x.args[1])
-                # ∘(f, g, h)(:x, :y, :z)
-                return Expr(:call, Expr(:call, ∘, funs...), x.args[2:end]...)
+            push!(funs, x.args[1])
+            # ∘(f, g, h)(:x, :y, :z)
+            return Expr(:call, Expr(:call, ∘, funs...), x.args[2:end]...)
         else
-            throw(Argumenterror("Not eligible for function composition"))
+            throw(ArgumentError("Not eligible for function composition"))
         end
     end
 end

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -93,7 +93,6 @@ function is_nested_fun_recursive(x::Expr, nested_once)
         return false
     end
 end
-
 make_composed(x) = x
 function make_composed(x::Expr)
     funs = Any[]
@@ -106,7 +105,7 @@ function make_composed(x::Expr)
             if !isempty(funs)
                 push!(funs, x.args[1])
                 # ∘(f, g, h)(:x, :y, :z)
-                return Expr(:call, Expr(:call, :∘, funs...), x.args[2:end]...)
+                return Expr(:call, Expr(:call, ∘, funs...), x.args[2:end]...)
             else
                 throw(Argumenterror("Not eligible for function composition"))
             end

--- a/test/function_compilation.jl
+++ b/test/function_compilation.jl
@@ -218,6 +218,18 @@ end
             slowtime = @timed select(df_wide, AsTable(:) => ByRow(t -> (sum ∘ skipmissing)(t)) => :y)
 
             (slowtime[2] > fasttime[2]) || @warn("Slow compilation")
+
+            @test @select(df, :y = f(g(:a, :b))).y == [3]
+
+            fasttime = @timed @select(df, :y = f(g(:a, :b)))
+            slowtime = @timed select(df, [:a, :b] => ((a, b) -> f(g(a, b))) => :y )
+            (slowtime[2] > fasttime[2]) || @warn("Slow compilation")
+
+            fasttime = @timed @rselect df_wide :y = sum(skipmissing(AsTable(:)))
+            slowtime = @timed select(df_wide, AsTable(:) => ByRow(t -> sum(skipmissing(t))) => :y)
+
+            (slowtime[2] > fasttime[2]) || @warn("Slow compilation")
+
         end
     end
 

--- a/test/function_compilation.jl
+++ b/test/function_compilation.jl
@@ -229,15 +229,40 @@ end
             slowtime = @timed select(df_wide, AsTable(:) => ByRow(t -> sum(skipmissing(t))) => :y)
 
             (slowtime[2] > fasttime[2]) || @warn("Slow compilation")
-
         end
     end
+
+    # Tests for correctness
+    t = @select df :y = sum(skipmissing(AsTable([:a, :b])))
+    @test t == DataFrame(y = [3])
+
+    t = @select df :y = f(g(:a, :b))
+    @test t == DataFrame(y = [3])
+
+    a_str = "a"
+    b_str = "b"
+
+    t = @select df :y = f(g($a_str, $(b_str)))
+    @test t == DataFrame(y = [3])
+
+    t = @select df :y = f(g(:a, $b_str))
+    @test t == DataFrame(y = [3])
+
+    t = @select df :y = sum(skipmissing(AsTable(Cols(:))))
+    @test t == DataFrame(y = [3])
+
+    t = @select df :y = sum(skipmissing(AsTable(Cols(:))))
+    @test t == DataFrame(y = [3])
 
     t = DataFramesMeta.@col :y = (identity ∘ first)(:x)
     @test t == ([:x] => (identity ∘ first => :y))
 
     t = DataFramesMeta.@col :y = identity(first(:x))
     @test t == ([:x] => (identity ∘ first => :y))
+
+    t = DataFramesMeta.@col :y = identity(first(AsTable(Cols(:))))
+
+    @test t == (AsTable(Cols(:)) => ((identity ∘ first) => :y))
 end
 
 end # module

--- a/test/function_compilation.jl
+++ b/test/function_compilation.jl
@@ -235,6 +235,9 @@ end
 
     t = DataFramesMeta.@col :y = (identity ∘ first)(:x)
     @test t == ([:x] => (identity ∘ first => :y))
+
+    t = DataFramesMeta.@col :y = identity(first(:x))
+    @test t == ([:x] => (identity ∘ first => :y))
 end
 
 end # module


### PR DESCRIPTION
This PR performs the following transformation

```
julia> DataFramesMeta.@col :y = first(last(:x))
[:x] => (first ∘ last => :y)
```

Tests are added and pass. I only need to fix one issue with macro hygiene, in case someone overloads `∘`. 
