### PR TITLE
Allow for keyword arguments

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -403,7 +403,28 @@ julia> @rtransform df @passmissing :x = parse(Int, :x_str)
 ## Passing keyword arguments to underlying DataFrames.jl functions
 
 All DataFramesMeta.jl macros allow passing of keyword arguments to their DataFrames.jl
-function equivelents. This can be done in two ways. When inputs are given as multiple 
+function equivelents. 
+
+| Macro | Base DataFrames.jl called |
+|-------|---------------------------|
+| @subset | `subset` |
+| @subset! | `subset!` |
+| @rsubset | `subset` |
+| @rsubset! | `subset!` |
+| @orderby | None (no keyword arguments supported) |
+| @rorderby | None (no keyword arguments supported) |
+| @by | `combine` |
+| @combine | `combine` |
+| @transform | `transform` |
+| @transform! | `transform!` |
+| @rtransform | `transform` |
+| @rtransform! | `transform!` |
+| @select | `select` |
+| @select! | `select!` |
+| @rselect | `select` |
+| @rselect! | `select!` |
+
+This can be done in two ways. When inputs are given as multiple 
 arguments, they are added at the end after a semi-colon `;`, as in
 
 ```julia

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -403,9 +403,10 @@ julia> @rtransform df @passmissing :x = parse(Int, :x_str)
 ## Passing keyword arguments to underlying DataFrames.jl functions
 
 All DataFramesMeta.jl macros allow passing of keyword arguments to their DataFrames.jl
-function equivelents. 
+function equivelents. The table below describes the correspondence between DataFramesMeta.jl
+macros and the function that is actually called by the macro. 
 
-| Macro | Base DataFrames.jl called |
+| Macro | Base DataFrames.jl function called |
 |-------|---------------------------|
 | @subset | `subset` |
 | @subset! | `subset!` |
@@ -436,7 +437,7 @@ julia> @rsubset(df, :x .== 1 ; view = true)
      │ Int64  Int64 
 ─────┼──────────────
    1 │     1      5
-   2 │     1      6```
+   2 │     1      6
 
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -400,6 +400,71 @@ julia> @rtransform df @passmissing :x = parse(Int, :x_str)
    3 │ missing  missing
 ```
 
+## Passing keyword arguments to underlying DataFrames.jl functions
+
+All DataFramesMeta.jl macros allow passing of keyword arguments to their DataFrames.jl
+function equivelents. This can be done in two ways. When inputs are given as multiple 
+arguments, they are added at the end after a semi-colon `;`, as in
+
+```julia
+julia> df = DataFrame(x = [1, 1, 2, 2], b = [5, 6, 7, 8]);
+
+julia> @rsubset(df, :x .== 1 ; view = true)
+2×2 SubDataFrame
+ Row │ x      b     
+     │ Int64  Int64 
+─────┼──────────────
+   1 │     1      5
+   2 │     1      6```
+
+```
+
+When inputs are given in "block" format, the last lines may be written
+`@kwarg key = value`, which indicates keyword arguments to be passed to `subset` function.
+
+```
+julia> df = DataFrame(x = [1, 1, 2, 2], b = [5, 6, 7, 8]);
+
+julia> @rsubset df begin
+           :x == 1
+           @kwarg view = true
+       end
+2×2 SubDataFrame
+ Row │ x      b     
+     │ Int64  Int64 
+─────┼──────────────
+   1 │     1      5
+   2 │     1      6
+```
+
+Just as with Julia functions, it is possible to pass keyword arguments as `Pair`s 
+programatically to DataFramesMeta.jl macros. 
+
+```
+julia> df = DataFrame(x = [1, 1, 2, 2], b = [5, 6, 7, 8]);
+
+julia> my_kwargs = [:view => true, :skipmissing => false];
+
+julia> @rsubset(df, :x .== 1; my_kwargs...)
+2×2 SubDataFrame
+ Row │ x      b     
+     │ Int64  Int64 
+─────┼──────────────
+   1 │     1      5
+   2 │     1      6
+
+julia> @rsubset df begin 
+           :x .== 1
+           @kwarg my_kwargs...
+       end
+2×2 SubDataFrame
+ Row │ x      b     
+     │ Int64  Int64 
+─────┼──────────────
+   1 │     1      5
+   2 │     1      6
+```
+
 ## Creating multiple columns at once with `@astable`
 
 Often new variables may depend on the same intermediate calculations. `@astable` makes it easy to create multiple

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -18,7 +18,7 @@ export @with,
        @transform, @select, @transform!, @select!,
        @rtransform, @rselect, @rtransform!, @rselect!,
        @eachrow, @eachrow!,
-       @byrow, @passmissing, @astable,
+       @byrow, @passmissing, @astable, @kwarg,
        @based_on, @where # deprecated
 
 const DOLLAR = raw"$"

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -775,7 +775,7 @@ function where_helper(x, args...)
 end
 
 """
-    @subset(d, i...)
+    @subset(d, i...; kwargs...)
 
 Select row subsets in `AbstractDataFrame`s and `GroupedDataFrame`s.
 
@@ -783,6 +783,9 @@ Select row subsets in `AbstractDataFrame`s and `GroupedDataFrame`s.
 
 * `d` : an AbstractDataFrame or GroupedDataFrame
 * `i...` : expression for selecting rows
+* `kwargs...` : keyword arguments passed to `DataFrames.subset`
+
+### Details
 
 Multiple `i` expressions are "and-ed" together.
 
@@ -965,7 +968,7 @@ end
 
 
 """
-    @rsubset(d, i...)
+    @rsubset(d, i...; kwargs...)
 
 Row-wise version of `@subset`, i.e. all operations use `@byrow` by
 default. See [`@subset`](@ref) for details.
@@ -1005,7 +1008,7 @@ end
 
 
 """
-    @subset!(d, i...)
+    @subset!(d, i...; kwargs...)
 
 Select row subsets in `AbstractDataFrame`s and `GroupedDataFrame`s,
 mutating the underlying data-frame in-place.
@@ -1014,6 +1017,9 @@ mutating the underlying data-frame in-place.
 
 * `d` : an AbstractDataFrame or GroupedDataFrame
 * `i...` : expression for selecting rows
+* `kwargs` : keyword arguments passed to `DataFrames.subset!`
+
+### Details
 
 Multiple `i` expressions are "and-ed" together.
 
@@ -1212,6 +1218,13 @@ end
 Sort rows by values in one of several columns or a transformation of columns.
 Always returns a fresh `DataFrame`. Does not accept a `GroupedDataFrame`.
 
+### Arguments
+
+* `d`: a `DataFrame` or `GroupedDataFrame`
+* `i...`: arguments on which to sort the object
+
+### Details
+
 When given a `DataFrame`, `@orderby` applies the transformation
 given by its arguments (but does not create new columns) and sorts
 the given `DataFrame` on the result, returning a new `DataFrame`.
@@ -1378,18 +1391,21 @@ function transform_helper(x, args...)
 end
 
 """
-    @transform(d, i...)
+    @transform(d, i...; kwargs...)
 
 Add additional columns or keys based on keyword-like arguments.
 
 ### Arguments
 
-* `d` : an `AbstractDataFrame`, or `GroupedDataFrame`
-* `i...` : keyword-like arguments defining new columns or keys, of the form `:y = f(:x)`
+* `d`: an `AbstractDataFrame`, or `GroupedDataFrame`
+* `i...`: transformations defining new columns or keys, of the form `:y = f(:x)`
+* `kwargs...`: keyword arguments passed to `DataFrames.transform`
 
 ### Returns
 
 * `::AbstractDataFrame` or `::GroupedDataFrame`
+
+### Details
 
 Inputs to `@transform` can come in two formats: a `begin ... end` block,
 in which case each line in the block is a separate
@@ -1509,7 +1525,7 @@ function rtransform_helper(x, args...)
 end
 
 """
-    @rtransform(x, args...)
+    @rtransform(x, args...; kwargs...)
 
 Row-wise version of `@transform`, i.e. all operations use `@byrow` by
 default. See [`@transform`](@ref) for details.
@@ -1535,7 +1551,7 @@ function transform!_helper(x, args...)
 end
 
 """
-    @transform!(d, i...)
+    @transform!(d, i...; kwargs...)
 
 Mutate `d` inplace to add additional columns or keys based on keyword-like
 arguments and return it. No copies of existing columns are made.
@@ -1543,12 +1559,14 @@ arguments and return it. No copies of existing columns are made.
 ### Arguments
 
 * `d` : an `AbstractDataFrame`, or `GroupedDataFrame`
-* `i...` : keyword-like arguments, of the form `:y = f(:x)` defining
-new columns or keys
+* `i...` : transformations of the form `:y = f(:x)` defining new columns or keys
+* `kwargs...`: keyword arguments passed to `DataFrames.transform!`
 
 ### Returns
 
-* `::DataFrame`
+* `::DataFrame` or a `GroupedDataFrame`
+
+### Details
 
 Inputs to `@transform!` can come in two formats: a `begin ... end` block,
 in which case each line in the block is a separate
@@ -1647,7 +1665,7 @@ function rtransform!_helper(x, args...)
 end
 
 """
-    @rtransform!(x, args...)
+    @rtransform!(x, args...; kwargs...)
 
 Row-wise version of `@transform!`, i.e. all operations use `@byrow` by
 default. See [`@transform!`](@ref) for details."""
@@ -1671,19 +1689,22 @@ function select_helper(x, args...)
 end
 
 """
-    @select(d, e...)
+    @select(d, i...; kwargs...)
 
 Select and transform columns.
 
 ### Arguments
 
 * `d` : an `AbstractDataFrame` or `GroupedDataFrame`
-* `e` :  keyword-like arguments, of the form `:y = f(:x)` specifying
+* `i` :  transformations of the form `:y = f(:x)` specifying
 new columns in terms of existing columns or symbols to specify existing columns
+* `kwargs` : keyword arguments passed to `DataFrames.select`
 
 ### Returns
 
-* `::AbstractDataFrame`
+* `::AbstractDataFrame` or a `GroupedDataFrame`
+
+### Details
 
 Inputs to `@select` can come in two formats: a `begin ... end` block,
 in which case each line in the block is a separate
@@ -1801,7 +1822,7 @@ function rselect_helper(x, args...)
 end
 
 """
-    @rselect(x, args...)
+    @rselect(x, args...; kwargs...)
 
 Row-wise version of `@select`, i.e. all operations use `@byrow` by
 default. See [`@select`](@ref) for details.
@@ -1827,19 +1848,22 @@ function select!_helper(x, args...)
 end
 
 """
-    @select!(d, e...)
+    @select!(d, i...; kwargs...)
 
 Mutate `d` in-place to retain only columns or transformations specified by `e` and return it. No copies of existing columns are made.
 
 ### Arguments
 
 * `d` : an AbstractDataFrame
-* `e` :  keyword-like arguments, of the form `:y = f(:x)` specifying
+* `i` : transformations of the form `:y = f(:x)` specifying
 new columns in terms of existing columns or symbols to specify existing columns
+* `kwargs` : keyword arguments passed to `DataFrames.select!`
 
 ### Returns
 
 * `::DataFrame`
+
+### Details
 
 Inputs to `@select!` can come in two formats: a `begin ... end` block,
 in which case each line in the block is a separate
@@ -1952,7 +1976,7 @@ function rselect!_helper(x, args...)
 end
 
 """
-    @rselect!(x, args...)
+    @rselect!(x, args...; kwargs...)
 
 Row-wise version of `@select!`, i.e. all operations use `@byrow` by
 default. See [`@select!`](@ref) for details.
@@ -1980,14 +2004,21 @@ function combine_helper(x, args...; deprecation_warning = false)
 end
 
 """
-    @combine(x, args...)
+    @combine(x, args...; kwargs...)
 
 Summarize a grouping operation
 
 ### Arguments
 
 * `x` : a `GroupedDataFrame` or `AbstractDataFrame`
-* `args...` : keyword-like arguments defining new columns, of the form `:y = f(:x)`
+* `args...` : transformations defining new columns, of the form `:y = f(:x)`
+* `kwargs`: : keyword arguments passed to `DataFrames.combine`
+
+### Results
+
+* A `DataFrame` or a `GroupedDataFrame`
+
+### Details
 
 Inputs to `@combine` can come in two formats: a `begin ... end` block,
 in which case each line in the block is a separate
@@ -2118,7 +2149,7 @@ function by_helper(x, what, args...)
 end
 
 """
-    @by(d::AbstractDataFrame, cols, e...)
+    @by(d::AbstractDataFrame, cols, e...; kwargs...)
 
 Split-apply-combine in one step.
 
@@ -2128,10 +2159,13 @@ Split-apply-combine in one step.
 * `cols` : a column indicator (Symbol, Int, Vector{Symbol}, etc.)
 * `e` :  keyword-like arguments, of the form `:y = f(:x)` specifying
 new columns in terms of column groupings
+* `kwargs` : keyword arguments passed to `DataFrames.combine`
 
 ### Returns
 
-* `::DataFrame`
+* `::DataFrame` or a `GroupedDataFrame`
+
+### Details
 
 Transformation inputs to `@by` can come in two formats: a `begin ... end` block,
 in which case each line in the block is a separate

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1933,7 +1933,7 @@ function by_helper(x, what, args...)
         # with keyword arguments, everything is shifted to
         # the right
         new_what = args[1]
-        args = (what, args...)
+        args = (what, args[2:end]...)
         what = new_what
     end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -732,7 +732,7 @@ function subset_helper(x, args...)
     exprs, outer_flags = create_args_vector(args...)
     t = (fun_to_vec(ex; no_dest=true, outer_flags=outer_flags) for ex in exprs)
     quote
-        $subset($x, $(t...); skipmissing=true, $(kw...))
+        $subset($x, $(t...); (skipmissing = true,)..., $(kw...))
     end
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -818,13 +818,12 @@ a semi-colon `;`, as in
 @subset(df, :a; skipmissing = false, view = true)
 ```
 
-
 When inputs are given in "block" format, the last lines may be written
 `@kwarg key = value`, which indicates keyword arguments to be passed to `subset` function.
 
 ```
 @subset df begin
-    :a
+    :a .== 1
     @kwarg skipmissing = false
     @kwarg view = true
 end
@@ -904,6 +903,25 @@ julia> @subset(df, :a .== 1)
      │ Int64?  String?
 ─────┼─────────────────
    1 │      1  x
+
+julia> @subset(df, :a .< 3; view = true)
+2×2 SubDataFrame
+ Row │ a       b
+     │ Int64?  String?
+─────┼─────────────────
+   1 │      1  x
+   2 │      2  y
+
+julia> @subset df begin
+           :a .< 3
+           @kwarg view = true
+       end
+2×2 SubDataFrame
+ Row │ a       b
+     │ Int64?  String?
+─────┼─────────────────
+   1 │      1  x
+   2 │      2  y
 ```
 """
 macro subset(x, args...)
@@ -932,7 +950,7 @@ end
 
 
 """
-    @subset(x, args...)
+    @where(x, args...)
 
 Deprecated version of `@subset`, see `?@subset` for details.
 """
@@ -1022,6 +1040,24 @@ end
 ```
 
 $ASTABLE_RHS_SUBSET_DOCS
+
+`@subset!` accepts the same keyword arguments as `DataFrames.subset!` and can be added in
+two ways. When inputs are given as multiple arguments, they are added at the end after
+a semi-colon `;`, as in
+
+```
+@subset!(df, :a; skipmissing = false)
+```
+
+When inputs are given in "block" format, the last lines may be written
+`@kwarg key = value`, which indicates keyword arguments to be passed to `subset!` function.
+
+```
+@subset! df begin
+    :a .== 1
+    @kwarg skipmissing = false
+end
+```
 
 ### Examples
 
@@ -1375,6 +1411,24 @@ $ASTABLE_MACRO_FLAG_DOCS
 
 $ASTABLE_RHS_SELECT_TRANSFORM_DOCS
 
+`@transform` accepts the same keyword arguments as `DataFrames.transform!` and can be added in
+two ways. When inputs are given as multiple arguments, they are added at the end after
+a semi-colon `;`, as in
+
+```
+@transform(gd, :x = :a .- 1; ungroup = false)
+```
+
+When inputs are given in "block" format, the last lines may be written
+`@kwarg key = value`, which indicates keyword arguments to be passed to `transform!` function.
+
+```
+@transform gd begin
+    :x = :a .- 1
+    @kwarg ungroup = false
+end
+```
+
 ### Examples
 
 ```jldoctest
@@ -1516,6 +1570,24 @@ $ASTABLE_MACRO_FLAG_DOCS
 
 $ASTABLE_RHS_SELECT_TRANSFORM_DOCS
 
+`@transform!` accepts the same keyword arguments as `DataFrames.transform!` and can be added in
+two ways. When inputs are given as multiple arguments, they are added at the end after
+a semi-colon `;`, as in
+
+```
+@transform!(gd, :x = :a .- 1; ungroup = false)
+```
+
+When inputs are given in "block" format, the last lines may be written
+`@kwarg key = value`, which indicates keyword arguments to be passed to `transform!` function.
+
+```
+@transform! gd begin
+    :x = :a .- 1
+    @kwarg ungroup = false
+end
+```
+
 ### Examples
 
 ```jldoctest
@@ -1632,6 +1704,24 @@ All transformations in the block will operate by row.
 $ASTABLE_MACRO_FLAG_DOCS
 
 $ASTABLE_RHS_SELECT_TRANSFORM_DOCS
+
+`@select` accepts the same keyword arguments as `DataFrames.select` and can be added in
+two ways. When inputs are given as multiple arguments, they are added at the end after
+a semi-colon `;`, as in
+
+```
+@select(df, :a; copycols = false)
+```
+
+When inputs are given in "block" format, the last lines may be written
+`@kwarg key = value`, which indicates keyword arguments to be passed to `select` function.
+
+```
+@select gd begin
+    :a
+    @select copycols = false
+end
+```
 
 ### Examples
 
@@ -1758,6 +1848,24 @@ $ASTABLE_MACRO_FLAG_DOCS
 
 $ASTABLE_RHS_SELECT_TRANSFORM_DOCS
 
+`@select!` accepts the same keyword arguments as `DataFrames.select!` and can be added in
+two ways. When inputs are given as multiple arguments, they are added at the end after
+a semi-colon `;`, as in
+
+```
+@select!(gd, :a; ungroup = false)
+```
+
+When inputs are given in "block" format, the last lines may be written
+`@kwarg key = value`, which indicates keyword arguments to be passed to `select!` function.
+
+```
+@select! gd begin
+    :a
+    @kwarg ungroup = false
+end
+```
+
 ### Examples
 
 ```jldoctest
@@ -1875,6 +1983,24 @@ and
 ```
 
 $ASTABLE_MACRO_FLAG_DOCS
+
+`@combine` accepts the same keyword arguments as `DataFrames.combine` and can be added in
+two ways. When inputs are given as multiple arguments, they are added at the end after
+a semi-colon `;`, as in
+
+```
+@combine(gd, :x = first(:a); ungroup = false)
+```
+
+When inputs are given in "block" format, the last lines may be written
+`@kwarg key = value`, which indicates keyword arguments to be passed to `combine` function.
+
+```
+@combine gd begin
+    :x = first(:a)
+    @kwarg ungroup = false
+end
+```
 
 ### Examples
 
@@ -2001,6 +2127,24 @@ and
 ```
 
 $ASTABLE_MACRO_FLAG_DOCS
+
+`@by` accepts the same keyword arguments as `DataFrames.combine` and can be added in
+two ways. When inputs are given as multiple arguments, they are added at the end after
+a semi-colon `;`, as in
+
+```
+@by(ds, :g, :x = first(:a); ungroup = false)
+```
+
+When inputs are given in "block" format, the last lines may be written
+`@kwarg key = value`, which indicates keyword arguments to be passed to `combine` function.
+
+```
+@by df :a begin
+    :x = first(:a)
+    @kwarg ungroup = false
+end
+```
 
 ### Examples
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1401,8 +1401,7 @@ macro transform(x, args...)
 end
 
 function rtransform_helper(x, args...)
-    x, args, kw = get_df_args_kwargs(x, args...)
-    exprs, outer_flags = create_args_vector(args...; wrap_byrow=true)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = true)
 
     t = (fun_to_vec(ex; gensym_names=false, outer_flags=outer_flags) for ex in exprs)
     quote

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -741,10 +741,10 @@ function subset_helper(x, args...)
 end
 
 function where_helper(x, args...)
-    exprs, outer_flags = create_args_vector(args...)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = false)
     t = (fun_to_vec(ex; no_dest=true, outer_flags=outer_flags) for ex in exprs)
     quote
-        $subset($x, $(t...); skipmissing=true)
+        $subset($x, $(t...); skipmissing=true, $(kw...))
     end
 end
 
@@ -1104,10 +1104,10 @@ end
 ##############################################################################
 # TODO: Determine which keyword arguments to expose to user
 function orderby_helper(x, args...)
-    exprs, outer_flags = create_args_vector(args...)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = false)
     t = (fun_to_vec(ex; gensym_names = true, outer_flags = outer_flags) for ex in exprs)
     quote
-        $DataFramesMeta.orderby($x, $(t...))
+        $orderby($x, $(t...); $(kw...))
     end
 end
 
@@ -1262,10 +1262,10 @@ macro orderby(d, args...)
 end
 
 function rorderby_helper(x, args...)
-    exprs, outer_flags = create_args_vector(args...; wrap_byrow=true)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = true)
     t = (fun_to_vec(ex; gensym_names=true, outer_flags=outer_flags) for ex in exprs)
     quote
-        $orderby($x, $(t...))
+        $orderby($x, $(t...); $(kw...))
     end
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -499,6 +499,32 @@ macro astable(args...)
     throw(ArgumentError("@astable only works inside DataFramesMeta macros."))
 end
 
+"""
+    @kwarg(args...)
+
+Inside of DataFramesMeta.jl macros, pass keyword arguments to the underlying
+DataFrames.jl function when arguments are written in "block" format.
+
+```
+julia> df = DataFrame(x = [1, 1, 2, 2], b = [5, 6, 7, 8]);
+
+julia> @rsubset df begin
+           :x == 1
+           @kwarg view = true
+       end
+2×2 SubDataFrame
+ Row │ x      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      5
+   2 │     1      6
+```
+
+!!!
+    This only has meaning inside DataFramesMeta.jl macros. It does not work outside
+    of DataFrames.jl macros.
+
+"""
 macro kwarg(args...)
     throw(ArgumentError("@kwarg only works inside DataFramesMeta macros."))
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -810,6 +810,26 @@ end
 
 $ASTABLE_RHS_SUBSET_DOCS
 
+`@subset` accepts the same keyword arguments as `DataFrames.subset` and can be added in
+two ways. When inputs are given as multiple arguments, they are added at the end after
+a semi-colon `;`, as in
+
+```
+@subset(df, :a; skipmissing = false, view = true)
+```
+
+
+When inputs are given in "block" format, the last lines may be written
+`@kwarg key = value`, which indicates keyword arguments to be passed to `subset` function.
+
+```
+@subset df begin
+    :a
+    @kwarg skipmissing = false
+    @kwarg view = true
+end
+```
+
 ### Examples
 
 ```jldoctest

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1184,7 +1184,6 @@ end
 ## @orderby
 ##
 ##############################################################################
-# TODO: Determine which keyword arguments to expose to user
 function orderby_helper(x, args...)
     x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = false)
     t = (fun_to_vec(ex; gensym_names = true, outer_flags = outer_flags) for ex in exprs)
@@ -2171,6 +2170,10 @@ When inputs are given in "block" format, the last lines may be written
     @kwarg ungroup = false
 end
 ```
+
+Though `@by` performs both `groupby` and `combine`, `@by` only forwards keyword arguments
+to `combine`, and not `groupby`. To pass keyword arguments to `groupby`, perform the
+`groupby` and `@combine` steps separately.
 
 ### Examples
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -499,6 +499,10 @@ macro astable(args...)
     throw(ArgumentError("@astable only works inside DataFramesMeta macros."))
 end
 
+macro kwarg(args...)
+    throw(ArgumentError("@kwarg only works inside DataFramesMeta macros."))
+end
+
 ##############################################################################
 ##
 ## @with

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -887,10 +887,11 @@ macro subset(x, args...)
 end
 
 function rsubset_helper(x, args...)
+    x, args, kw = get_df_args_kwargs(x, args...)
     exprs, outer_flags = create_args_vector(args...; wrap_byrow=true)
     t = (fun_to_vec(ex; no_dest=true, outer_flags=outer_flags) for ex in exprs)
     quote
-        $subset($x, $(t...); skipmissing=true)
+        $subset($x, $(t...); (skipmissing = true,)..., $(kw...))
     end
 end
 
@@ -917,18 +918,20 @@ macro where(x, args...)
 end
 
 function subset!_helper(x, args...)
+    x, args, kw = get_df_args_kwargs(x, args...)
     exprs, outer_flags = create_args_vector(args...)
     t = (fun_to_vec(ex; no_dest=true, outer_flags=outer_flags) for ex in exprs)
     quote
-        $subset!($x, $(t...); skipmissing=true)
+        $subset!($x, $(t...); (;skipmissing = true,)..., $(kw...))
     end
 end
 
 function rsubset!_helper(x, args...)
+    x, args, kw = get_df_args_kwargs(x, args...)
     exprs, outer_flags = create_args_vector(args...; wrap_byrow=true)
     t = (fun_to_vec(ex; no_dest=true, outer_flags=outer_flags) for ex in exprs)
     quote
-        $subset!($x, $(t...); skipmissing=true)
+        $subset!($x, $(t...); (skipmissing = true,)..., $(kw...))
     end
 end
 
@@ -1095,7 +1098,7 @@ end
 ## @orderby
 ##
 ##############################################################################
-
+# TODO: Determine which keyword arguments to expose to user
 function orderby_helper(x, args...)
     exprs, outer_flags = create_args_vector(args...)
     t = (fun_to_vec(ex; gensym_names = true, outer_flags = outer_flags) for ex in exprs)
@@ -1258,7 +1261,7 @@ function rorderby_helper(x, args...)
     exprs, outer_flags = create_args_vector(args...; wrap_byrow=true)
     t = (fun_to_vec(ex; gensym_names=true, outer_flags=outer_flags) for ex in exprs)
     quote
-        $DataFramesMeta.orderby($x, $(t...))
+        $orderby($x, $(t...))
     end
 end
 
@@ -1281,10 +1284,11 @@ end
 
 
 function transform_helper(x, args...)
+    x, args, kw = get_df_args_kwargs(x, args...)
     exprs, outer_flags = create_args_vector(args...)
     t = (fun_to_vec(ex; gensym_names = false, outer_flags = outer_flags) for ex in exprs)
     quote
-        $DataFrames.transform($x, $(t...))
+        $transform($x, $(t...);  $(kw...))
     end
 end
 
@@ -1393,11 +1397,12 @@ macro transform(x, args...)
 end
 
 function rtransform_helper(x, args...)
+    x, args, kw = get_df_args_kwargs(x, args...)
     exprs, outer_flags = create_args_vector(args...; wrap_byrow=true)
 
     t = (fun_to_vec(ex; gensym_names=false, outer_flags=outer_flags) for ex in exprs)
     quote
-        $DataFrames.transform($x, $(t...))
+        $transform($x, $(t...); $(kw...))
     end
 end
 
@@ -1419,10 +1424,11 @@ end
 
 
 function transform!_helper(x, args...)
+    x, args, kw = get_df_args_kwargs(x, args...)
     exprs, outer_flags = create_args_vector(args...)
     t = (fun_to_vec(ex; gensym_names = false, outer_flags = outer_flags) for ex in exprs)
     quote
-        $DataFrames.transform!($x, $(t...))
+        $transform!($x, $(t...); $(kw...))
     end
 end
 
@@ -1512,11 +1518,12 @@ macro transform!(x, args...)
 end
 
 function rtransform!_helper(x, args...)
+    x, args, kw = get_df_args_kwargs(x, args...)
     exprs, outer_flags = create_args_vector(args...; wrap_byrow=true)
 
     t = (fun_to_vec(ex; gensym_names=false, outer_flags=outer_flags) for ex in exprs)
     quote
-        $DataFrames.transform!($x, $(t...))
+        $transform!($x, $(t...); $(kw...))
     end
 end
 
@@ -1536,10 +1543,11 @@ end
 ##############################################################################
 
 function select_helper(x, args...)
+    x, args, kw = get_df_args_kwargs(x, args...)
     exprs, outer_flags = create_args_vector(args...)
     t = (fun_to_vec(ex; gensym_names = false, outer_flags = outer_flags) for ex in exprs)
     quote
-        $DataFrames.select($x, $(t...))
+        $select($x, $(t...); $(kw...))
     end
 end
 
@@ -1647,11 +1655,12 @@ macro select(x, args...)
 end
 
 function rselect_helper(x, args...)
+    x, args, kw = get_df_args_kwargs(x, args...)
     exprs, outer_flags = create_args_vector(args...; wrap_byrow=true)
 
     t = (fun_to_vec(ex; gensym_names=false, outer_flags=outer_flags) for ex in exprs)
     quote
-        $DataFrames.select($x, $(t...))
+        $select($x, $(t...); $(kw...))
     end
 end
 
@@ -1673,10 +1682,11 @@ end
 ##############################################################################
 
 function select!_helper(x, args...)
+    x, args, kw = get_df_args_kwargs(x, args...)
     exprs, outer_flags = create_args_vector(args...)
     t = (fun_to_vec(ex; gensym_names = false, outer_flags = outer_flags) for ex in exprs)
     quote
-        $DataFrames.select!($x, $(t...))
+        $select!($x, $(t...); $(kw...))
     end
 end
 
@@ -1779,11 +1789,12 @@ macro select!(x, args...)
 end
 
 function rselect!_helper(x, args...)
+    x, args, kw = get_df_args_kwargs(x, args...)
     exprs, outer_flags = create_args_vector(args...; wrap_byrow=true)
 
     t = (fun_to_vec(ex; gensym_names=false, outer_flags=outer_flags) for ex in exprs)
     quote
-        $DataFrames.select!($x, $(t...))
+        $select!($x, $(t...); $(kw...))
     end
 end
 
@@ -1804,6 +1815,7 @@ end
 ##############################################################################
 
 function combine_helper(x, args...; deprecation_warning = false)
+    x, args, kw = get_df_args_kwargs(x, args...)
     deprecation_warning && @warn "`@based_on` is deprecated. Use `@combine` instead."
 
     exprs, outer_flags = create_args_vector(args...)
@@ -1811,7 +1823,7 @@ function combine_helper(x, args...; deprecation_warning = false)
     t = (fun_to_vec(ex; gensym_names = false, outer_flags = outer_flags) for ex in exprs)
 
     quote
-        $DataFrames.combine($x, $(t...))
+        $combine($x, $(t...); $(kw...))
     end
 end
 
@@ -1917,13 +1929,14 @@ end
 ##############################################################################
 
 function by_helper(x, what, args...)
-    # Only allow one argument when returning a Table object
+    # TODO: Determine keyword arguments sent to gropby
+    x, args, kw = get_df_args_kwargs(x, args...)
     exprs, outer_flags = create_args_vector(args...)
 
     t = (fun_to_vec(ex; gensym_names = false, outer_flags = outer_flags) for ex in exprs)
 
     quote
-        $DataFrames.combine($groupby($x, $what), $(t...))
+        $combine($groupby($x, $what), $(t...); $(kw...))
     end
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -732,8 +732,8 @@ write
 ##############################################################################
 
 function subset_helper(x, args...)
-    x, args, kw = get_df_args_kwargs(x, args...)
-    exprs, outer_flags = create_args_vector(args...)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = false)
+
     t = (fun_to_vec(ex; no_dest=true, outer_flags=outer_flags) for ex in exprs)
     quote
         $subset($x, $(t...); (skipmissing = true,)..., $(kw...))
@@ -891,8 +891,8 @@ macro subset(x, args...)
 end
 
 function rsubset_helper(x, args...)
-    x, args, kw = get_df_args_kwargs(x, args...)
-    exprs, outer_flags = create_args_vector(args...; wrap_byrow=true)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = true)
+
     t = (fun_to_vec(ex; no_dest=true, outer_flags=outer_flags) for ex in exprs)
     quote
         $subset($x, $(t...); (skipmissing = true,)..., $(kw...))
@@ -922,8 +922,8 @@ macro where(x, args...)
 end
 
 function subset!_helper(x, args...)
-    x, args, kw = get_df_args_kwargs(x, args...)
-    exprs, outer_flags = create_args_vector(args...)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = false)
+
     t = (fun_to_vec(ex; no_dest=true, outer_flags=outer_flags) for ex in exprs)
     quote
         $subset!($x, $(t...); (;skipmissing = true,)..., $(kw...))
@@ -931,8 +931,8 @@ function subset!_helper(x, args...)
 end
 
 function rsubset!_helper(x, args...)
-    x, args, kw = get_df_args_kwargs(x, args...)
-    exprs, outer_flags = create_args_vector(args...; wrap_byrow=true)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = true)
+
     t = (fun_to_vec(ex; no_dest=true, outer_flags=outer_flags) for ex in exprs)
     quote
         $subset!($x, $(t...); (skipmissing = true,)..., $(kw...))
@@ -1288,8 +1288,8 @@ end
 
 
 function transform_helper(x, args...)
-    x, args, kw = get_df_args_kwargs(x, args...)
-    exprs, outer_flags = create_args_vector(args...)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = false)
+
     t = (fun_to_vec(ex; gensym_names = false, outer_flags = outer_flags) for ex in exprs)
     quote
         $transform($x, $(t...);  $(kw...))
@@ -1427,8 +1427,8 @@ end
 
 
 function transform!_helper(x, args...)
-    x, args, kw = get_df_args_kwargs(x, args...)
-    exprs, outer_flags = create_args_vector(args...)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = false)
+
     t = (fun_to_vec(ex; gensym_names = false, outer_flags = outer_flags) for ex in exprs)
     quote
         $transform!($x, $(t...); $(kw...))
@@ -1521,8 +1521,7 @@ macro transform!(x, args...)
 end
 
 function rtransform!_helper(x, args...)
-    x, args, kw = get_df_args_kwargs(x, args...)
-    exprs, outer_flags = create_args_vector(args...; wrap_byrow=true)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = true)
 
     t = (fun_to_vec(ex; gensym_names=false, outer_flags=outer_flags) for ex in exprs)
     quote
@@ -1546,8 +1545,8 @@ end
 ##############################################################################
 
 function select_helper(x, args...)
-    x, args, kw = get_df_args_kwargs(x, args...)
-    exprs, outer_flags = create_args_vector(args...)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = false)
+
     t = (fun_to_vec(ex; gensym_names = false, outer_flags = outer_flags) for ex in exprs)
     quote
         $select($x, $(t...); $(kw...))
@@ -1658,8 +1657,7 @@ macro select(x, args...)
 end
 
 function rselect_helper(x, args...)
-    x, args, kw = get_df_args_kwargs(x, args...)
-    exprs, outer_flags = create_args_vector(args...; wrap_byrow=true)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = true)
 
     t = (fun_to_vec(ex; gensym_names=false, outer_flags=outer_flags) for ex in exprs)
     quote
@@ -1685,8 +1683,8 @@ end
 ##############################################################################
 
 function select!_helper(x, args...)
-    x, args, kw = get_df_args_kwargs(x, args...)
-    exprs, outer_flags = create_args_vector(args...)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = false)
+
     t = (fun_to_vec(ex; gensym_names = false, outer_flags = outer_flags) for ex in exprs)
     quote
         $select!($x, $(t...); $(kw...))
@@ -1792,8 +1790,7 @@ macro select!(x, args...)
 end
 
 function rselect!_helper(x, args...)
-    x, args, kw = get_df_args_kwargs(x, args...)
-    exprs, outer_flags = create_args_vector(args...; wrap_byrow=true)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = true)
 
     t = (fun_to_vec(ex; gensym_names=false, outer_flags=outer_flags) for ex in exprs)
     quote
@@ -1818,10 +1815,9 @@ end
 ##############################################################################
 
 function combine_helper(x, args...; deprecation_warning = false)
-    x, args, kw = get_df_args_kwargs(x, args...)
-    deprecation_warning && @warn "`@based_on` is deprecated. Use `@combine` instead."
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = false)
 
-    exprs, outer_flags = create_args_vector(args...)
+    deprecation_warning && @warn "`@based_on` is deprecated. Use `@combine` instead."
 
     t = (fun_to_vec(ex; gensym_names = false, outer_flags = outer_flags) for ex in exprs)
 
@@ -1933,8 +1929,7 @@ end
 
 function by_helper(x, what, args...)
     # TODO: Determine keyword arguments sent to gropby
-    x, args, kw = get_df_args_kwargs(x, args...)
-    exprs, outer_flags = create_args_vector(args...)
+    x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = false)
 
     t = (fun_to_vec(ex; gensym_names = false, outer_flags = outer_flags) for ex in exprs)
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -728,10 +728,11 @@ write
 ##############################################################################
 
 function subset_helper(x, args...)
+    x, args, kw = get_df_args_kwargs(x, args...)
     exprs, outer_flags = create_args_vector(args...)
     t = (fun_to_vec(ex; no_dest=true, outer_flags=outer_flags) for ex in exprs)
     quote
-        $subset($x, $(t...); skipmissing=true)
+        $subset($x, $(t...); skipmissing=true, $(kw...))
     end
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1928,7 +1928,15 @@ end
 ##############################################################################
 
 function by_helper(x, what, args...)
-    # TODO: Determine keyword arguments sent to gropby
+    # Handle keyword arguments initially due the gouping instruction, what
+    if x isa Expr && x.head === :parameters
+        # with keyword arguments, everything is shifted to
+        # the right
+        new_what = args[1]
+        args = (what, args...)
+        what = new_what
+    end
+
     x, exprs, outer_flags, kw = get_df_args_kwargs(x, args...; wrap_byrow = false)
 
     t = (fun_to_vec(ex; gensym_names = false, outer_flags = outer_flags) for ex in exprs)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -520,7 +520,7 @@ julia> @rsubset df begin
    2 │     1      6
 ```
 
-!!!
+!!! note
     This only has meaning inside DataFramesMeta.jl macros. It does not work outside
     of DataFrames.jl macros.
 

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -1,3 +1,15 @@
+function get_df_args_kwargs(x, args...)
+    if x isa Expr && x.head === :parameters
+        kw = x.args
+        x = first(args)
+        args = args[2:end]
+    else
+        kw = []
+    end
+
+    return (x, args, kw)
+end
+
 function addkey!(membernames, nam)
     if !haskey(membernames, nam)
         membernames[nam] = gensym()

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -420,10 +420,8 @@ end
 
 function get_kw_from_macro_call(e::Expr)
     nv = e.args[3]
-    nme = nv.args[1]
-    val = nv.args[2]
 
-    Expr(:kw, nme, val)
+    return nv
 end
 
 """

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -411,7 +411,6 @@ function get_df_args_kwargs(x, args...; wrap_byrow = false)
 
     transforms, outer_flags, kw = create_args_vector!(kw, args...; wrap_byrow = wrap_byrow)
 
-
     return (x, transforms, outer_flags, kw)
 end
 

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -553,11 +553,6 @@ cr = "c"
     @test_throws MethodError @eval @select(df, :n = sum(Between(:i, :t)))
 end
 
-@testset "Keyword arguments failure" begin
-    @test_throws LoadError @eval @transform(df; :n = :i)
-    @test_throws LoadError @eval @select(df; :n = :i)
-end
-
 @testset "with" begin
     df = DataFrame(A = 1:3, B = [2, 1, 2])
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -149,7 +149,6 @@ newvar = :n
 
 @testset "Limits of @combine" begin
     @test_throws MethodError @eval @combine(gd, :n = sum(Between(:i, :t)))
-    @test_throws LoadError @eval @combine(gd; :n = mean(:i))
     @test_throws ArgumentError @eval @combine(gd, :n = mean(:i) + mean(cols(1)))
 end
 

--- a/test/keyword_arguments.jl
+++ b/test/keyword_arguments.jl
@@ -7,17 +7,36 @@ using Statistics
 
 const ≅ = isequal
 
+df = DataFrame(a = [1, 1, 2, 2], b = [3, 4, 5, missing])
+gd = groupby(df, :a)
+
 # @subset
 # skipmissing, view, ungroup
+df2 = @subset(df, :a .== 1; view = true)
+@test df2 ≅ view(df, df.a .== 1, :)
+@test_throws ArgumentError @subset(df, :b .== 3; skipmissing = false)
+gd2 = @subset(gd, [true, true]; ungroup = false)
+@test gd2 ≅ groupby(df, :a)
 
 # @rsubset
 # skipmissing, view, ungroup
+df2 = @rsubset(df, :a == 1; view = true)
+@test df2 ≅ view(df, df.a .== 1, :)
+@test_throws ArgumentError @rsubset(df, :b == 3; skipmissing = false)
+gd2 = @rsubset(gd, first(true); ungroup = false)
+@test gd2 ≅ groupby(df, :a)
 
 # @subset!
-# skipmissing, view, ungroup
+# skipmissing, ungroup
+@test_throws ArgumentError @subset!(copy(df), :b .== 3; skipmissing = false)
+gd2 = @subset!(deepcopy(gd), [true, true]; ungroup = false)
+@test gd2 ≅ groupby(df, :a)
 
 # @rsubset!
-# skipmissing, view, ungroup
+# skipmissing, ungroup
+@test_throws ArgumentError @rsubset!(copy(df), :b == 3; skipmissing = false)
+gd2 = @rsubset!(deepcopy(gd), first(true); ungroup = false)
+@test gd2 ≅ groupby(df, :a)
 
 # @orderby # Not added
 

--- a/test/keyword_arguments.jl
+++ b/test/keyword_arguments.jl
@@ -401,5 +401,4 @@ end
     @test df2 == correct
 end
 
-
 end # module

--- a/test/keyword_arguments.jl
+++ b/test/keyword_arguments.jl
@@ -1,0 +1,42 @@
+module TestKW
+
+using Test
+using DataFrames
+using DataFramesMeta
+using Statistics
+
+const ≅ = isequal
+
+# @subset
+
+# @rsubset
+
+# @subset!
+
+# @rsubset!
+
+# @orderby # Not added
+
+# @rorderby # Not added
+
+# @select
+
+# @rselect
+
+# @select!
+
+# @rselect!
+
+# @transform
+
+# @rtransform
+
+# @transform!
+
+# @rtransform!
+
+# @combine
+
+# @by
+
+end # module

--- a/test/keyword_arguments.jl
+++ b/test/keyword_arguments.jl
@@ -8,35 +8,55 @@ using Statistics
 const ≅ = isequal
 
 # @subset
+# skipmissing, view, ungroup
 
 # @rsubset
+# skipmissing, view, ungroup
 
 # @subset!
+# skipmissing, view, ungroup
 
 # @rsubset!
+# skipmissing, view, ungroup
 
 # @orderby # Not added
 
 # @rorderby # Not added
 
 # @select
+# copycols, renamecols (not relevant)
+# keepkeys, ungroup
 
 # @rselect
+# copycols, renamecols (not relevant)
+# keepkeys, ungroup
 
 # @select!
+# renamecols (not relevant), ungroup
 
 # @rselect!
+# renamecols (not relevant), ungroup
 
 # @transform
+# copycols, renamecols (not relevant)
+# ungroup
 
 # @rtransform
+# copycols, renamecols (not relevant)
+# ungroup
 
 # @transform!
+# renamecols (not relevant), ungroup
 
 # @rtransform!
+# renamecols (not relevant), ungroup
 
 # @combine
+# renamecols (not relevant), keepkeys,
+# ungroup
 
 # @by
+# renamecols (not relevant), keepkeys,
+# ungroup
 
 end # module

--- a/test/keyword_arguments.jl
+++ b/test/keyword_arguments.jl
@@ -352,5 +352,54 @@ end
     @test gd2 ≅ correct
 end
 
+@testset "Pairs and keyword arguments" begin
+    correct = @view df[df.a .== 1, :]
+
+    t = [:view => true]
+    ts = [:skipmissing => true, :view => true]
+
+    df2 = @rsubset(df, :a == 1; :view => true)
+    @test df2 == correct
+
+    df2 = @rsubset(df, :a == 1; :view => true, :skipmissing => false)
+    @test df2 == correct
+
+    df2 = @rsubset(df, :a == 1; t...)
+    @test df2 == correct
+
+    df2 = @rsubset(df, :a == 1; ts...)
+    @test df2 == correct
+
+    df2 = @rsubset df begin
+        :a == 1
+        @kwarg :view => true
+    end
+    @test df2 == correct
+
+    df2 = @rsubset df begin
+        :a == 1
+        @kwarg [:view => true]...
+    end
+    @test df2 == correct
+
+    df2 = @rsubset df begin
+        :a == 1
+        @kwarg [:view => true, :skipmissing => false]...
+    end
+    @test df2 == correct
+
+    df2 = @rsubset df begin
+        :a == 1
+        @kwarg t...
+    end
+    @test df2 == correct
+
+    df2 = @rsubset df begin
+        :a == 1
+        @kwarg ts...
+    end
+    @test df2 == correct
+end
+
 
 end # module

--- a/test/keyword_arguments.jl
+++ b/test/keyword_arguments.jl
@@ -13,7 +13,7 @@ gd = groupby(df, :a)
 # @subset
 # skipmissing, view, ungroup
 @testset "@subset keyword" begin
-    correcty = view(df, df.a .== 1, :)
+    correct = view(df, df.a .== 1, :)
     df2 = @subset(df, :a .== 1; view = true)
     @test df2 ≅ correct
 
@@ -34,8 +34,8 @@ gd = groupby(df, :a)
         @kwarg ungroup = false
     end
     @test gd2 ≅ correct
-
 end
+
 # @rsubset
 # skipmissing, view, ungroup
 @testset "@rsubset keyword" begin
@@ -209,16 +209,19 @@ end
 # copycols, renamecols (not relevant)
 # ungroup
 @testset "@transform keyword" begin
-    correct = df.a
+    correct = df.b
 
     df2 = @transform(df, :a; copycols = false)
-    @test df2.a === correct
+    @test df2 ≅ df
+    # The :a above counts as a transformation, and
+    # is thus copied
+    @test df2.b === correct
 
     df2 = @transform df begin
         :a
         @kwarg copycols = false
     end
-    @test df2.a === correct
+    @test df2.b === correct
 
     correct = gd
 
@@ -236,16 +239,16 @@ end
 # copycols, renamecols (not relevant)
 # ungroup
 @testset "@rtransform keyword" begin
-    correct = df.a
+    correct = df.b
 
     df2 = @rtransform(df, :a; copycols = false)
-    @test df2.a === correct
+    @test df2.b === correct
 
     df2 = @rtransform df begin
         :a
         @kwarg copycols = false
     end
-    @test df2.a === correct
+    @test df2.b === correct
 
     correct = gd
 
@@ -261,32 +264,93 @@ end
 
 # @transform!
 # renamecols (not relevant), ungroup
-gd2 = @transform!(deepcopy(gd), :b; ungroup = false)
-@test gd2 ≅ gd
+@testset "@transform! keyword" begin
+    correct = df.a
+
+    correct = gd
+
+    gd2 = @transform(deepcopy(gd), :b; ungroup = false)
+    @test gd2 ≅ correct
+
+    gd2 = @transform deepcopy(gd) begin
+        :b
+        @kwarg ungroup = false
+    end
+    @test gd2 ≅ correct
+end
+
 
 # @rtransform!
 # renamecols (not relevant), ungroup
-gd2 = @transform!(deepcopy(gd), :b; ungroup = false)
-@test gd2 ≅ gd
+@testset "@rtransform! keyword" begin
+    correct = df.a
+
+    correct = gd
+
+    gd2 = @rtransform(deepcopy(gd), :b; ungroup = false)
+    @test gd2 ≅ correct
+
+    gd2 = @rtransform deepcopy(gd) begin
+        :b
+        @kwarg ungroup = false
+    end
+    @test gd2 ≅ correct
+end
 
 # @combine
 # renamecols (not relevant), keepkeys,
 # ungroup
-df2 = @combine(gd, :b_f = first(:b); keepkeys = true)
+@testset "@combine keyword" begin
+    correct = DataFrame(a = [1, 2], b_f = [3, 5])
 
-@test sort(df2, :a) ≅ DataFrame(a = [1, 2], b_f = [3, 5])
+    df2 = @combine(gd, :b_f = first(:b); keepkeys = true)
+    @test sort(df2, :a) ≅ correct
 
-gd2 = @combine(gd, :b = :b; ungroup = false)
-@test gd2 ≅ gd
+    df2 = @combine gd begin
+        :b_f = first(:b)
+        @kwarg keepkeys = true
+    end
+    @test sort(df2, :a) ≅ correct
+
+    correct = gd
+
+    gd2 = @combine(gd, :b = :b; ungroup = false)
+    @test gd2 ≅ correct
+
+    gd2 = @combine gd begin
+        :b = :b
+        @kwarg ungroup = false
+    end
+    @test gd2 ≅ correct
+end
+
 
 # @by
 # renamecols (not relevant), keepkeys,
 # ungroup
-df2 = @by(df, :a, :b_f = first(:b); keepkeys = true)
+@testset "@combine keyword" begin
+    correct = DataFrame(a = [1, 2], b_f = [3, 5])
 
-@test sort(df2, :a) ≅ DataFrame(a = [1, 2], b_f = [3, 5])
+    df2 = @by(df, :a, :b_f = first(:b); keepkeys = true)
+    @test sort(df2, :a) ≅ correct
 
-gd2 = @by(df, :a, :b = :b; ungroup = false)
-@test gd2 ≅ gd
+    df2 = @by df :a begin
+        :b_f = first(:b)
+        @kwarg keepkeys = true
+    end
+    @test sort(df2, :a) ≅ correct
+
+    correct = gd
+
+    gd2 = @by(df, :a, :b = :b; ungroup = false)
+    @test gd2 ≅ correct
+
+    gd2 = @by df :a begin
+        :b = :b
+        @kwarg ungroup = false
+    end
+    @test gd2 ≅ correct
+end
+
 
 end # module

--- a/test/keyword_arguments.jl
+++ b/test/keyword_arguments.jl
@@ -39,43 +39,91 @@ gd2 = @rsubset!(deepcopy(gd), first(true); ungroup = false)
 @test gd2 ≅ groupby(df, :a)
 
 # @orderby # Not added
+@test_throws MethodError @orderby(df, :a; view = true)
 
 # @rorderby # Not added
+@test_throws MethodError @rorderby(df, :a; view = true)
 
 # @select
 # copycols, renamecols (not relevant)
 # keepkeys, ungroup
+df2 = @select(df, :a; copycols = false)
+@test df2.a === df.a
+
+df2 = @select(gd, :b; keepkeys = true)
+@test df2 ≅ df
+
+gd2 = @select(gd, :b; ungroup = false)
+@test gd2 ≅ gd
 
 # @rselect
 # copycols, renamecols (not relevant)
 # keepkeys, ungroup
+df2 = @rselect(df, :a; copycols = false)
+@test df2.a === df.a
+
+df2 = @rselect(gd, :b; keepkeys = true)
+@test df2 ≅ df
+
+gd2 = @rselect(gd, :b; ungroup = false)
+@test gd2 ≅ gd
 
 # @select!
 # renamecols (not relevant), ungroup
+gd2 = @rselect!(deepcopy(gd), :b; ungroup = false)
+@test gd2 ≅ gd
 
 # @rselect!
 # renamecols (not relevant), ungroup
+gd2 = @rselect!(deepcopy(gd), :b; ungroup = false)
+@test gd2 ≅ gd
 
 # @transform
 # copycols, renamecols (not relevant)
 # ungroup
+df2 = @transform(df, :a; copycols = false)
+@test df2.a === df.a
+
+gd2 = @transform(gd, :b; ungroup = false)
+@test gd2 ≅ gd
 
 # @rtransform
 # copycols, renamecols (not relevant)
 # ungroup
+df2 = @transform(df, :a; copycols = false)
+@test df2.a === df.a
+
+gd2 = @transform(gd, :b; ungroup = false)
+@test gd2 ≅ gd
 
 # @transform!
 # renamecols (not relevant), ungroup
+gd2 = @transform!(deepcopy(gd), :b; ungroup = false)
+@test gd2 ≅ gd
 
 # @rtransform!
 # renamecols (not relevant), ungroup
+gd2 = @transform!(deepcopy(gd), :b; ungroup = false)
+@test gd2 ≅ gd
 
 # @combine
 # renamecols (not relevant), keepkeys,
 # ungroup
+df2 = @combine(gd, :b_f = first(:b); keepkeys = true)
+
+@test sort(df2, :a) ≅ DataFrame(a = [1, 2], b_f = [3, 5])
+
+gd2 = @combine(gd, :b = :b; ungroup = false)
+@test gd2 ≅ gd
 
 # @by
 # renamecols (not relevant), keepkeys,
 # ungroup
+df2 = @by(df, :a, :b_f = first(:b); keepkeys = true)
+
+@test sort(df2, :a) ≅ DataFrame(a = [1, 2], b_f = [3, 5])
+
+gd2 = @by(df, :a, :b = :b; ungroup = false)
+@test gd2 ≅ gd
 
 end # module

--- a/test/keyword_arguments.jl
+++ b/test/keyword_arguments.jl
@@ -12,31 +12,90 @@ gd = groupby(df, :a)
 
 # @subset
 # skipmissing, view, ungroup
-df2 = @subset(df, :a .== 1; view = true)
-@test df2 ≅ view(df, df.a .== 1, :)
-@test_throws ArgumentError @subset(df, :b .== 3; skipmissing = false)
-gd2 = @subset(gd, [true, true]; ungroup = false)
-@test gd2 ≅ groupby(df, :a)
+@testset "@subset keyword" begin
+    correcty = view(df, df.a .== 1, :)
+    df2 = @subset(df, :a .== 1; view = true)
+    @test df2 ≅ correct
 
+    df2 = @subset df begin
+        :a .== 1
+        @kwarg view = true
+    end
+    @test df2 ≅ correct
+
+    @test_throws ArgumentError @subset(df, :b .== 3; skipmissing = false)
+
+    correct = gd
+    gd2 = @subset(gd, fill(true, length(:a)); ungroup = false)
+    @test gd2 ≅ correct
+
+    gd2 = @subset gd begin
+        fill(true, length(:a))
+        @kwarg ungroup = false
+    end
+    @test gd2 ≅ correct
+
+end
 # @rsubset
 # skipmissing, view, ungroup
-df2 = @rsubset(df, :a == 1; view = true)
-@test df2 ≅ view(df, df.a .== 1, :)
-@test_throws ArgumentError @rsubset(df, :b == 3; skipmissing = false)
-gd2 = @rsubset(gd, first(true); ungroup = false)
-@test gd2 ≅ groupby(df, :a)
+@testset "@rsubset keyword" begin
+    correct = view(df, df.a .== 1, :)
+
+    df2 = @rsubset(df, :a == 1; view = true)
+    @test df2 ≅ view(df, df.a .== 1, :)
+
+    df2 = @rsubset df begin
+        :a == 1
+        @kwarg view = true
+    end
+    @test df2 ≅ correct
+
+    @test_throws ArgumentError @rsubset(df, :b == 3; skipmissing = false)
+
+    correct = gd
+    gd2 = @rsubset(gd, first(true); ungroup = false)
+    @test gd2 ≅ correct
+
+    gd2 = @rsubset gd begin
+        first(true);
+        @kwarg ungroup = false
+    end
+    @test gd ≅ correct
+end
 
 # @subset!
 # skipmissing, ungroup
-@test_throws ArgumentError @subset!(copy(df), :b .== 3; skipmissing = false)
-gd2 = @subset!(deepcopy(gd), [true, true]; ungroup = false)
-@test gd2 ≅ groupby(df, :a)
+@testset "@subset! keyword" begin
+    @test_throws ArgumentError @subset!(copy(df), :b .== 3; skipmissing = false)
+
+    correct = gd
+
+    gd2 = @subset!(deepcopy(gd), [true, true]; ungroup = false)
+    @test gd2 ≅ correct
+
+    gd2 = @subset! deepcopy(gd) begin
+        [true, true]
+        @kwarg ungroup = false
+    end
+    @test gd2 ≅ correct
+end
 
 # @rsubset!
 # skipmissing, ungroup
-@test_throws ArgumentError @rsubset!(copy(df), :b == 3; skipmissing = false)
-gd2 = @rsubset!(deepcopy(gd), first(true); ungroup = false)
-@test gd2 ≅ groupby(df, :a)
+@testset "@rsubset! keyword" begin
+    @test_throws ArgumentError @rsubset!(copy(df), :b == 3; skipmissing = false)
+
+    correct = gd
+
+    gd2 = @rsubset!(deepcopy(gd), first(true); ungroup = false)
+    @test gd2 ≅ correct
+
+    gd2 = @rsubset! deepcopy(gd) begin
+        first(true)
+        @kwarg ungroup = false
+    end
+    @test gd2 ≅ correct
+end
 
 # @orderby # Not added
 @test_throws MethodError @orderby(df, :a; view = true)
@@ -47,54 +106,158 @@ gd2 = @rsubset!(deepcopy(gd), first(true); ungroup = false)
 # @select
 # copycols, renamecols (not relevant)
 # keepkeys, ungroup
-df2 = @select(df, :a; copycols = false)
-@test df2.a === df.a
+@testset "@select keyword" begin
+    correct = DataFrame(a = df.a; copycols = false)
 
-df2 = @select(gd, :b; keepkeys = true)
-@test df2 ≅ df
+    df2 = @select(df, :a; copycols = false)
+    @test (df2 ≅ correct && (df2.a === correct.a))
 
-gd2 = @select(gd, :b; ungroup = false)
-@test gd2 ≅ gd
+    df2 = @select df begin
+        :a
+        @kwarg copycols = false
+    end
+    @test (df2 ≅ correct && (df2.a === correct.a))
+
+    correct = df
+    df2 = @select(gd, :b; keepkeys = true)
+    @test df2 ≅ correct
+
+    df2 = @select gd begin
+        :b
+        @kwarg keepkeys = true
+    end
+    @test df2 ≅ correct
+
+    correct = gd
+
+    gd2 = @select(gd, :b; ungroup = false)
+    gd2 = @select gd begin
+        :b
+        @kwarg ungroup = false
+    end
+    @test gd2 ≅ correct
+end
 
 # @rselect
 # copycols, renamecols (not relevant)
 # keepkeys, ungroup
-df2 = @rselect(df, :a; copycols = false)
-@test df2.a === df.a
+@testset "@rselect keyword" begin
+    correct = DataFrame(a = df.a; copycols = false)
 
-df2 = @rselect(gd, :b; keepkeys = true)
-@test df2 ≅ df
+    df2 = @rselect(df, :a; copycols = false)
+    @test (df2 ≅ correct && (df2.a === correct.a))
 
-gd2 = @rselect(gd, :b; ungroup = false)
-@test gd2 ≅ gd
+    df2 = @rselect df begin
+        :a
+        @kwarg copycols = false
+    end
+    @test (df2 ≅ correct && (df2.a === correct.a))
+
+    correct = df
+    df2 = @rselect(gd, :b; keepkeys = true)
+    @test df2 ≅ correct
+
+    df2 = @rselect gd begin
+        :b
+        @kwarg keepkeys = true
+    end
+    @test df2 ≅ correct
+
+    correct = gd
+
+    gd2 = @rselect(gd, :b; ungroup = false)
+    gd2 = @rselect gd begin
+        :b
+        @kwarg ungroup = false
+    end
+    @test gd2 ≅ correct
+end
 
 # @select!
 # renamecols (not relevant), ungroup
-gd2 = @rselect!(deepcopy(gd), :b; ungroup = false)
-@test gd2 ≅ gd
+@testset "@select! keyword" begin
+    correct = gd
+
+    gd2 = @select!(deepcopy(gd), :b; ungroup = false)
+    @test gd2 ≅ correct
+
+    @select! deepcopy(gd) begin
+        :b
+        @kwarg ungroup = false
+    end
+
+    @test gd2 ≅ correct
+end
 
 # @rselect!
 # renamecols (not relevant), ungroup
-gd2 = @rselect!(deepcopy(gd), :b; ungroup = false)
-@test gd2 ≅ gd
+@testset "@rselect! keyword" begin
+    correct = gd
+
+    gd2 = @rselect!(deepcopy(gd), :b; ungroup = false)
+    @test gd2 ≅ correct
+
+    @rselect! deepcopy(gd) begin
+        :b
+        @kwarg ungroup = false
+    end
+
+    @test gd2 ≅ correct
+end
 
 # @transform
 # copycols, renamecols (not relevant)
 # ungroup
-df2 = @transform(df, :a; copycols = false)
-@test df2.a === df.a
+@testset "@transform keyword" begin
+    correct = df.a
 
-gd2 = @transform(gd, :b; ungroup = false)
-@test gd2 ≅ gd
+    df2 = @transform(df, :a; copycols = false)
+    @test df2.a === correct
+
+    df2 = @transform df begin
+        :a
+        @kwarg copycols = false
+    end
+    @test df2.a === correct
+
+    correct = gd
+
+    gd2 = @transform(gd, :b; ungroup = false)
+    @test gd2 ≅ correct
+
+    gd2 = @transform gd begin
+        :b
+        @kwarg ungroup = false
+    end
+    @test gd2 ≅ correct
+end
 
 # @rtransform
 # copycols, renamecols (not relevant)
 # ungroup
-df2 = @transform(df, :a; copycols = false)
-@test df2.a === df.a
+@testset "@rtransform keyword" begin
+    correct = df.a
 
-gd2 = @transform(gd, :b; ungroup = false)
-@test gd2 ≅ gd
+    df2 = @rtransform(df, :a; copycols = false)
+    @test df2.a === correct
+
+    df2 = @rtransform df begin
+        :a
+        @kwarg copycols = false
+    end
+    @test df2.a === correct
+
+    correct = gd
+
+    gd2 = @rtransform(gd, :b; ungroup = false)
+    @test gd2 ≅ correct
+
+    gd2 = @rtransform gd begin
+        :b
+        @kwarg ungroup = false
+    end
+    @test gd2 ≅ correct
+end
 
 # @transform!
 # renamecols (not relevant), ungroup


### PR DESCRIPTION
This just adds keyword arguments for calls of the form `@subset(df, :a; view = true)`, rather than the multi-line version

```
@subset df begin 
    :a 
end
```

I have added this for `@subset` but not others yet. 