### PR TITLE
Fix #328 parsing bug try 2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.5'
+          - '1.6'
+          - '1.8'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Chain = "0.5"
 DataFrames = "1"
 MacroTools = "0.5"
 Reexport = "0.2, 1"
-julia = "1"
+julia = "1.6"
 OrderedCollections = "1"
 
 [extras]

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -255,7 +255,7 @@ function get_source_fun(function_expr; exprflags = deepcopy(DEFAULT_FLAGS))
         # extract source symbols from quotenodes
         source = args_to_selectors(function_expr.args[2].args)
         fun_t = function_expr.args[1]
-        fun = :(DataFrames.ByRow($fun_t))
+        fun = :($ByRow($fun_t))
     elseif is_nested_fun_recursive(function_expr, false)
         composed_expr = make_composed(function_expr)
         # Repeat clean up from simple non-broadcast above

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -247,7 +247,7 @@ function get_source_fun(function_expr; exprflags = deepcopy(DEFAULT_FLAGS))
         # .+ to +
         if startswith(string(fun_t), '.')
             f_sym_without_dot = Symbol(chop(string(fun_t), head = 1, tail = 0))
-            fun = :(DataFrames.ByRow($f_sym_without_dot))
+            fun = :($ByRow($f_sym_without_dot))
         else
             fun = fun_t
         end

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -61,16 +61,38 @@ end
 end
 
 @testset "broadcasted binary operators" begin
-    df = DataFrame(x = 1, y = 2)
+    df = DataFrame(x = [1, 2], y = [3, 4])
 
     df2 = @select df :z = first(:x .+ :y)
-    @test df2 == DataFrame(z = 3)
+    @test df2 == DataFrame(z = [4, 4])
 
     df2 = @by df :x :y = first(:y .* :y)
 
-    @test df2 == DataFrame(x = 1, y = 4)
+    @test df2 == DataFrame(x = [1, 2], y = [9, 16])
 
     df2 = @select df :y = first(last(:y))
+
+    @test df2 == DataFrame(y = [4, 4])
+
+    df2 = @select df :z = .+(:x)
+
+    @test df2 == DataFrame(z = [1, 2])
+
+    df2 = @select df :z = .+(first(:x))
+
+    @test df2 == DataFrame(z = [1, 1])
+
+    df2 = @select df :z = first(.*(:x))
+
+    @test df2 == DataFrame(z = 1)
+
+    df2 = @select df :z = .+(.*(:x))
+
+    @test df2 == DataFrame(z = 1)
+
+    df2 = @select df :z = .+(.*(:x, :y))
+
+    @test df2 == DataFrame(z = 2)
 
     @test df2 == DataFrame(y = 2)
 
@@ -84,6 +106,7 @@ end
     :a = maximum(:y .* :z))
 
     @test df2 == DataFrame(x = [1, 2, 3], a = [true, true, false])
+
 end
 
 end # module

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -60,4 +60,30 @@ end
     @test n === nothing
 end
 
+@testset "broadcasted binary operators" begin
+    df = DataFrame(x = 1, y = 2)
+
+    df2 = @select df :z = first(:x .+ :y)
+    @test df2 == DataFrame(z = 3)
+
+    df2 = @by df :x :y = first(:y .* :y)
+
+    @test df2 == DataFrame(x = 1, y = 4)
+
+    df2 = @select df :y = first(last(:y))
+
+    @test df2 == DataFrame(y = 2)
+
+    df = DataFrame(
+        x = [1, 1, 2, 2, 3, 3],
+        y = [true, false, true, false, true, false],
+        z = [true, true, true, false, false, false])
+
+    df2 = @by(df,
+    :x,
+    :a = maximum(:y .* :z))
+
+    @test df2 == DataFrame(x = [1, 2, 3], a = [true, true, false])
+end
+
 end # module


### PR DESCRIPTION
Just takes the bugfix from #341 

I cluttered up #341 with docstrings, and the diff is actually a little important. 

Ideal scenario: create `Expr(., f)` 

This works on 1.6+ but tests currently pass on 1.0 and 1.5. Including this fix would require changing compatability. This is a bug-fix so I don't want to do that. 

Current scenario: use `$ByRow($f)`

This is not should  to `Expr(., f)` except for extremely contrived edge cases which I do not know about. 

Once we release 1.0, we will depend on DataFrames.jl version which require 1.6 and above, and therefore depend on 1.6. 

The docstrings and explanations will be added in a later PR. 