### PR TITLE
Make a release for 0.15.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# DataFramesMeta v0.15.0 Release notes
+
+* Added support for `Not`, `All`, and `Cols` in `@select`, making it easier to keep or drop many columns at once. ([#372](https://github.com/JuliaData/DataFramesMeta.jl/pull/372))
+* Added the `@groupby` macro, which provides an easier syntax for grouping data frames ([#373](https://github.com/JuliaData/DataFramesMeta.jl/pull/373))
+
 # DataFramesMeta v0.14.1 Release notes
 * Fixed a bug where `ByRow` was not properly identified if DataFramesMeta.jl was `import`ed ([#366](https://github.com/JuliaData/DataFramesMeta.jl/pull/366))
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # DataFramesMeta v0.15.0 Release notes
 
+* Added `@note!` and `@label!`, along with `printlabels` and `printnotes` to make working with metadata easier. ([#377](https://github.com/JuliaData/DataFramesMeta.jl/pull/377))
 * Added support for `Not`, `All`, and `Cols` in `@select`, making it easier to keep or drop many columns at once. ([#372](https://github.com/JuliaData/DataFramesMeta.jl/pull/372))
 * Added the `@groupby` macro, which provides an easier syntax for grouping data frames ([#373](https://github.com/JuliaData/DataFramesMeta.jl/pull/373))
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # DataFramesMeta v0.15.0 Release notes
 
+* Fixed macro hygiene issues ([#384](https://github.com/JuliaData/DataFramesMeta.jl/pull/384))
+* Fixed a bug with broadcasting in `@astable` ([#382](https://github.com/JuliaData/DataFramesMeta.jl/pull/382))
 * Added `@note!` and `@label!`, along with `printlabels` and `printnotes` to make working with metadata easier. ([#377](https://github.com/JuliaData/DataFramesMeta.jl/pull/377))
 * Added support for `Not`, `All`, and `Cols` in `@select`, making it easier to keep or drop many columns at once. ([#372](https://github.com/JuliaData/DataFramesMeta.jl/pull/372))
 * Added the `@groupby` macro, which provides an easier syntax for grouping data frames ([#373](https://github.com/JuliaData/DataFramesMeta.jl/pull/373))

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFramesMeta"
 uuid = "1313f7d8-7da2-5740-9ea0-a2ca25f37964"
-version = "0.14.1"
+version = "0.15.0"
 
 [deps]
 Chain = "8be319e6-bccf-4806-a6f7-6fae938471bc"


### PR DESCRIPTION
We've added two new features since the last release

* Added support for `Not`, `All`, and `Cols` in `@select`, making it easier to keep or drop many columns at once. ([#372](https://github.com/JuliaData/DataFramesMeta.jl/pull/372))
* Added the `@groupby` macro, which provides an easier syntax for grouping data frames ([#373](https://github.com/JuliaData/DataFramesMeta.jl/pull/373))

I always think I will wait until the next feature (metadata syntax, or `@when`) until the next release. But realistically we should keep a faster clip of releases. 

I put 0.15.0 as the release number because of the new features. We really need to get to 1.0. Which I think I will do after metadata is merged. 

@bkamins 