### PR TITLE
Revert to version 15.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFramesMeta"
 uuid = "1313f7d8-7da2-5740-9ea0-a2ca25f37964"
-version = "0.15.1"
+version = "0.15.0"
 
 [deps]
 Chain = "8be319e6-bccf-4806-a6f7-6fae938471bc"


### PR DESCRIPTION
As detailed on Slack

1. I tried to release 0.15.0. But then unknowingly messed it up by commenting in the Registry PR
2. I realized there was a bug in the documentation. So I hastily released a 0.15.1 rather than perform some hack about documentation. 
3. The 0.15.1 registry PR was blocked because I "skipped" 015.0. 

This gives me an opening to avoid the 0.15.1 release at all. I'm just going to re-set the version to 0.15.0 and then register that version. 