### PR TITLE
Remove print statement

### DIFF
--- a/src/parsing_astable.jl
+++ b/src/parsing_astable.jl
@@ -21,7 +21,6 @@ function replace_syms_astable!(inputs_to_function::AbstractDict,
         return e.args[2]
     end
 
-    println(e)
     col = get_column_expr(e)
     if col !== nothing
         return conditionally_add_symbols!(inputs_to_function, lhs_assignments, col)


### PR DESCRIPTION
When working on #382 I added a `print` statement for debugging. This never got deleted :(