### PR TITLE
Bump Chain.jl compat

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# DataFramesMeta v0.15.2 Release notes
+* Bumped the Chain.jl compat entry in the Project.toml ([#382](https://github.com/JuliaData/DataFramesMeta.jl/pull/391))
+
 # DataFramesMeta v0.15.1 Release notes
 
 * Deleted an errant `print` statement introduced in [#382](https://github.com/JuliaData/DataFramesMeta.jl/pull/382) ([#389](https://github.com/JuliaData/DataFramesMeta.jl/pull/389))

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 TableMetadataTools = "9ce81f87-eacc-4366-bf80-b621a3098ee2"
 
 [compat]
-Chain = "0.6"
+Chain = "0.5, 0.6"
 DataFrames = "1"
 MacroTools = "0.5"
 OrderedCollections = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 TableMetadataTools = "9ce81f87-eacc-4366-bf80-b621a3098ee2"
 
 [compat]
-Chain = "0.5"
+Chain = "0.6"
 DataFrames = "1"
 MacroTools = "0.5"
 OrderedCollections = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFramesMeta"
 uuid = "1313f7d8-7da2-5740-9ea0-a2ca25f37964"
-version = "0.15.1"
+version = "0.15.2"
 
 [deps]
 Chain = "8be319e6-bccf-4806-a6f7-6fae938471bc"


### PR DESCRIPTION
Chain.jl has been at 0.6 for a month now That's a problem! If you add `Chain`, then `DataFamesMeta`, you get a super old version. 