### PR TITLE
Simplify index.md first example

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -35,10 +35,16 @@ See below the convenience of DataFramesMeta compared to DataFrames.
 df = DataFrame(a = [1, 2], b = [3, 4]);
 
 # With DataFrames
-transform(df, [:a, :b] => ((a, b) -> a .* b .+ first(a) .- sum(b)) => :c);
+transform(df, [:a, :b] => ((x, y) -> x + y) => :c)
 
 # With DataFramesMeta
-@transform(df, :c = :a .* :b .+ first(:a) .- sum(:b))
+@transform(df, :c = :a + :b)
+
+# With DataFrames
+subset(df, :a => ByRow(==(2)))
+
+# With DataFramesMeta
+@rsubset(df, :a == 2)
 ```
 
 To reference columns inside DataFramesMeta macros, use `Symbol`s. For example, use `:x`


### PR DESCRIPTION
As a generalization, the highlights of DataFramesMeta.jl I have seen across the internet take unreadable DataFrames.jl syntax and make it readable with DataFramesMeta.jl, especially using multiple chained transformations. I think a better strategy is to take readable DataFrames.jl syntax and make it simple with DataFramesMeta.jl.

I cannot appreciate what DataFramesMeta.jl is doing if I cannot parse the Base DataFrames.jl syntax well enough to understand the goal, and the longer chained examples add to the feeling that DataFramesMeta.jl is more than most need. The package authors probably think the goal will be obvious by reading the DataFramesMeta.jl code, but since there are macros involved, the syntax could mean anything.

----

This instance is not particularly egregious. However, the `first`, `sum`, and broadcasting `.`'s are not different between the two pacakge syntaxes, so why overcomplicate the example.