### PR TITLE
Update Chain.jl Compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 TableMetadataTools = "9ce81f87-eacc-4366-bf80-b621a3098ee2"
 
 [compat]
-Chain = "0.5, 0.6"
+Chain = "0.5, 0.6, 1"
 DataFrames = "1"
 MacroTools = "0.5"
 OrderedCollections = "1"


### PR DESCRIPTION
Chain updated to v1.0 to indicate stability of API, with no braking changes to the API from v0.6 

See https://github.com/jkrumbiegel/Chain.jl/releases/tag/v1.0.0

This updates the compat bound on DataFramesMeta

Without the compat change the DataFramesMeta gets downgraded to v0.7.1 on my machine