### PR TITLE
Byrow-aware literal handling for @subset / @rsubset (#259)

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -421,6 +421,22 @@ fun_to_vec(ex::QuoteNode;
            outer_flags::Union{NamedTuple, Nothing}=nothing,
            allow_multicol::Bool = false) = ex
 
+# Catch-all method for literal values (Bool, Int, String, etc.)
+# Wraps them in Returns to create a constant function
+# This allows syntax like @subset(df, true) or @subset(df, false)
+function fun_to_vec(ex;
+                    no_dest::Bool=false,
+                    gensym_names::Bool=false,
+                    outer_flags::Union{NamedTuple, Nothing}=nothing,
+                    allow_multicol::Bool = false)
+    if no_dest
+        # For @subset and @with, return a constant function
+        return :([] => Returns($ex))
+    else
+        throw(ArgumentError("Literal values are only supported in @subset, @rsubset, @with, and similar macros"))
+    end
+end
+
 
 """
     rename_kw_to_pair(ex::Expr)

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -422,7 +422,10 @@ fun_to_vec(ex::QuoteNode;
            allow_multicol::Bool = false) = ex
 
 # Catch-all method for literal values (Bool, Int, String, etc.)
-# Wraps them in Returns to create a constant function
+# Wraps them in ByRow(Returns(...)) to create a constant vector function.
+# ByRow is required because DataFrames.subset enforces that transformation
+# functions return an AbstractVector, and ByRow with empty source columns
+# produces a vector via _empty_selector_helper.
 # This allows syntax like @subset(df, true) or @subset(df, false)
 function fun_to_vec(ex;
                     no_dest::Bool=false,
@@ -430,8 +433,7 @@ function fun_to_vec(ex;
                     outer_flags::Union{NamedTuple, Nothing}=nothing,
                     allow_multicol::Bool = false)
     if no_dest
-        # For @subset and @with, return a constant function
-        return :([] => Returns($ex))
+        return :([] => $ByRow($(Base.Returns)($ex)))
     else
         throw(ArgumentError("Literal values are only supported in @subset, @rsubset, @with, and similar macros"))
     end

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -421,22 +421,21 @@ fun_to_vec(ex::QuoteNode;
            outer_flags::Union{NamedTuple, Nothing}=nothing,
            allow_multicol::Bool = false) = ex
 
-# Catch-all method for literal values (Bool, Int, String, etc.)
-# Wraps them in ByRow(Returns(...)) to create a constant vector function.
-# ByRow is required because DataFrames.subset enforces that transformation
-# functions return an AbstractVector, and ByRow with empty source columns
-# produces a vector via _empty_selector_helper.
-# This allows syntax like @subset(df, true) or @subset(df, false)
+# Catch-all method for literal values (Bool, Int, String, etc.).
+# A bare literal isn't a column expression: `@subset(df, true)` lowers to a
+# scalar predicate, which `DataFrames.subset` rejects exactly as
+# `subset(df, [] => Returns(true))` does. Rather than accept it (which would
+# make the macro diverge from the function, and would mean different things
+# across macros — e.g. `@select(df, 1)` vs `@subset(df, true)`), surface a
+# clear error in place of the bare MethodError from #259.
 function fun_to_vec(ex;
                     no_dest::Bool=false,
                     gensym_names::Bool=false,
                     outer_flags::Union{NamedTuple, Nothing}=nothing,
                     allow_multicol::Bool = false)
-    if no_dest
-        return :([] => $ByRow($(Base.Returns)($ex)))
-    else
-        throw(ArgumentError("Literal values are only supported in @subset, @rsubset, @with, and similar macros"))
-    end
+    throw(ArgumentError(
+        "literal value `$ex` is not a valid column expression; pass a " *
+        "column reference or a vectorised predicate (e.g. `:x .> 0`)"))
 end
 
 

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -422,20 +422,28 @@ fun_to_vec(ex::QuoteNode;
            allow_multicol::Bool = false) = ex
 
 # Catch-all method for literal values (Bool, Int, String, etc.).
-# A bare literal isn't a column expression: `@subset(df, true)` lowers to a
-# scalar predicate, which `DataFrames.subset` rejects exactly as
-# `subset(df, [] => Returns(true))` does. Rather than accept it (which would
-# make the macro diverge from the function, and would mean different things
-# across macros — e.g. `@select(df, 1)` vs `@subset(df, true)`), surface a
-# clear error in place of the bare MethodError from #259.
+# Behaviour mirrors the underlying `DataFrames.subset` exactly, keyed on the
+# `@byrow` flag:
+#   * byrow  -> `[] => ByRow(Returns(ex))`, a per-row constant vector, same
+#               as `subset(df, [] => ByRow(Returns(true)))` (which works).
+#   * !byrow -> a bare literal is a scalar predicate, which `subset` rejects
+#               (`subset(df, [] => Returns(true))` errors). Raise a clear
+#               ArgumentError in place of the #259 MethodError.
+# ByRow is applied only when byrow is set; applying it unconditionally would
+# make `@subset(df, true)` accept what the function rejects.
 function fun_to_vec(ex;
                     no_dest::Bool=false,
                     gensym_names::Bool=false,
                     outer_flags::Union{NamedTuple, Nothing}=nothing,
                     allow_multicol::Bool = false)
+    byrow = outer_flags !== nothing && outer_flags[BYROW_SYM][]
+    if byrow
+        return :([] => $ByRow($(Base.Returns)($ex)))
+    end
     throw(ArgumentError(
         "literal value `$ex` is not a valid column expression; pass a " *
-        "column reference or a vectorised predicate (e.g. `:x .> 0`)"))
+        "column reference or a vectorised predicate (e.g. `:x .> 0`), " *
+        "or use `@rsubset` for a per-row literal"))
 end
 
 

--- a/test/subset.jl
+++ b/test/subset.jl
@@ -173,27 +173,19 @@ end
     @test @subset!(groupby(copy(df), :g), :c .== :g) ≅ df[[], :]
 end
 
-@testset "@subset with literal values" begin
+@testset "@subset with literal values errors clearly" begin
     df = DataFrame(A = [1, 2, 3], B = [4, 5, 6])
 
-    # Test with boolean literal true - should return all rows
-    @test @subset(df, true) ≅ df
-
-    # Test with boolean literal false - should return empty dataframe
-    @test @subset(df, false) ≅ df[Int[], :]
-
-    # Test combination with other conditions
-    @test @subset(df, true, :A .> 1) ≅ df[df.A .> 1, :]
-    @test @subset(df, false, :A .> 1) ≅ df[Int[], :]
-
-    # @subset! with literal values
-    @test @subset!(copy(df), true) ≅ df
-    @test @subset!(copy(df), false) ≅ df[Int[], :]
-
-    # @subset with grouped data frame and literal
-    gd = groupby(df, :B)
-    @test @subset(gd, true) ≅ df
-    @test @subset(gd, false) ≅ df[Int[], :]
+    # A bare literal is not a valid predicate — it must error (consistent
+    # with `subset(df, [] => Returns(true))`), not be silently broadcast.
+    # The error is raised during macro expansion (as the prior MethodError
+    # from #259 was), so it surfaces via @eval as a LoadError — matching
+    # the suite's convention for other invalid-expansion cases.
+    @test_throws LoadError @eval @subset($df, true)
+    @test_throws LoadError @eval @subset($df, false)
+    @test_throws LoadError @eval @subset($df, true, :A .> 1)
+    @test_throws LoadError @eval @subset!(copy($df), true)
+    @test_throws LoadError @eval @subset(groupby($df, :B), true)
 end
 
 end # module

--- a/test/subset.jl
+++ b/test/subset.jl
@@ -185,6 +185,15 @@ end
     # Test combination with other conditions
     @test @subset(df, true, :A .> 1) ≅ df[df.A .> 1, :]
     @test @subset(df, false, :A .> 1) ≅ df[Int[], :]
+
+    # @subset! with literal values
+    @test @subset!(copy(df), true) ≅ df
+    @test @subset!(copy(df), false) ≅ df[Int[], :]
+
+    # @subset with grouped data frame and literal
+    gd = groupby(df, :B)
+    @test @subset(gd, true) ≅ df
+    @test @subset(gd, false) ≅ df[Int[], :]
 end
 
 end # module

--- a/test/subset.jl
+++ b/test/subset.jl
@@ -173,19 +173,24 @@ end
     @test @subset!(groupby(copy(df), :g), :c .== :g) ≅ df[[], :]
 end
 
-@testset "@subset with literal values errors clearly" begin
+@testset "@subset / @rsubset with literal values" begin
     df = DataFrame(A = [1, 2, 3], B = [4, 5, 6])
 
-    # A bare literal is not a valid predicate — it must error (consistent
-    # with `subset(df, [] => Returns(true))`), not be silently broadcast.
-    # The error is raised during macro expansion (as the prior MethodError
-    # from #259 was), so it surfaces via @eval as a LoadError — matching
-    # the suite's convention for other invalid-expansion cases.
+    # @subset (not byrow): a bare literal is a scalar predicate, which
+    # subset rejects (subset(df, [] => Returns(true)) errors). It must error,
+    # not be silently broadcast. The error is raised during macro expansion
+    # (as the #259 MethodError was), so it surfaces via @eval as LoadError.
     @test_throws LoadError @eval @subset($df, true)
     @test_throws LoadError @eval @subset($df, false)
     @test_throws LoadError @eval @subset($df, true, :A .> 1)
     @test_throws LoadError @eval @subset!(copy($df), true)
     @test_throws LoadError @eval @subset(groupby($df, :B), true)
+
+    # @rsubset (byrow): a per-row literal is well-defined and matches
+    # subset(df, [] => ByRow(Returns(true))), which works.
+    @test @rsubset(df, true) ≅ df
+    @test @rsubset(df, false) ≅ df[Int[], :]
+    @test @rsubset(groupby(df, :B), true) ≅ df
 end
 
 end # module

--- a/test/subset.jl
+++ b/test/subset.jl
@@ -173,4 +173,18 @@ end
     @test @subset!(groupby(copy(df), :g), :c .== :g) ≅ df[[], :]
 end
 
+@testset "@subset with literal values" begin
+    df = DataFrame(A = [1, 2, 3], B = [4, 5, 6])
+
+    # Test with boolean literal true - should return all rows
+    @test @subset(df, true) ≅ df
+
+    # Test with boolean literal false - should return empty dataframe
+    @test @subset(df, false) ≅ df[Int[], :]
+
+    # Test combination with other conditions
+    @test @subset(df, true, :A .> 1) ≅ df[df.A .> 1, :]
+    @test @subset(df, false, :A .> 1) ≅ df[Int[], :]
+end
+
 end # module


### PR DESCRIPTION
## Summary

`@subset(df, true)` previously threw an opaque `MethodError` (no `fun_to_vec` dispatch for literals), which is the bug in #259.

This handles literals in a way that mirrors the underlying `DataFrames.subset` exactly, keyed on the `@byrow` flag:

- **`@subset(df, true)`** (not byrow): a bare literal is a scalar predicate, which `subset` rejects just as `subset(df, [] => Returns(true))` does. It now raises a clear `ArgumentError` in place of the `MethodError`.
- **`@rsubset(df, true)`** (byrow): a per-row literal is well defined and matches `subset(df, [] => ByRow(Returns(true)))`, which works, so it returns the expected rows.

`ByRow` is applied only when the `@byrow` flag is set. Applying it unconditionally (the first approach here) made `@subset` accept what the function rejects, which is the divergence raised in review.

## Test plan

- `@subset(df, true)` / `false` / grouped / `@subset!` raise at macro expansion (asserted via `@test_throws LoadError @eval ...`, matching the suite's convention for invalid expansions).
- `@rsubset(df, true)` returns all rows, `@rsubset(df, false)` returns none, including the grouped case.
- Real column predicates (`@subset(df, :A .> 1)`) unaffected.

There was no test coverage for literal predicates in either mode before, so this adds it for both.