### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Fixes #422. Since this repo had no CompatHelper workflow, expect a flurry of compat update PRs afterwards.

Yaml script copy-pasted from https://discourse.julialang.org/t/psa-github-dependabot-now-supports-julia/134997